### PR TITLE
Display entities in tabbed format

### DIFF
--- a/pca-ui/src/www/src/routes/Dashboard/Entities.js
+++ b/pca-ui/src/www/src/routes/Dashboard/Entities.js
@@ -6,7 +6,7 @@ export const Entities = ({ data }) => {
   return data.length ? (
     <Tabs defaultActiveKey={data[0].Name}>
       {data.map((e, i) => (
-        <Tab title={toSentenceCase(e.Name)} eventKey={e.Name} className="pt-2">
+        <Tab title={toSentenceCase(e.Name)} eventKey={e.Name} className="pt-4">
           {e.Values.map((x, j) => (
             <Tag
               key={j}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously, all entity types were displayed in one stack. If there were many entities (or categories), this would take a large amount of space.

This PR reverts the design of the entity section to split each category into a tab.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
