### PR TITLE
Fix Load more button

### DIFF
--- a/pca-ui/src/www/src/routes/Home.js
+++ b/pca-ui/src/www/src/routes/Home.js
@@ -19,7 +19,6 @@ function Home({ setAlert }) {
   };
 
   const getKey = (pageIndex, previousPageData) => {
-    console.log({ pageIndex, previousPageData });
     if (previousPageData && !previousPageData.StartKey) return null;
     if (pageIndex === 0) return `/list`;
 
@@ -40,7 +39,8 @@ function Home({ setAlert }) {
     (size > 0 && data && typeof data[size - 1] === "undefined");
   const isEmpty = data?.[0]?.length === 0;
   const isReachingEnd =
-    isEmpty || (data && data[data.length - 1]?.length < config.api.pageSize);
+    isEmpty ||
+    (data && data[data.length - 1].Records?.length < config.api.pageSize);
 
   const details = (data || []).map((d) => d.Records).flat();
   useDangerAlert(error, setAlert);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix Load More Button on Homepage

Previously, the button would get stuck displaying "Loading" if no more records were available. This PR fixes the logic to display "No more to load" in the case of no more available records

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
