### PR TITLE
Display Label based on API response

### DIFF
--- a/pca-ui/src/www/src/components/ContactTable.js
+++ b/pca-ui/src/www/src/components/ContactTable.js
@@ -9,11 +9,10 @@ const columns = [
   { label: "Job Name", value: (d) => d.jobName },
   { label: "Timestamp", value: (d) => Formatter.Timestamp(d.timestamp) },
   {
-    label: "Caller Sentiment",
-    value: (d) => <SentimentIcon score={d?.callerSentimentScore} />,
+    label: "Customer Sentiment",
   },
   {
-    label: "Caller Sentiment Trend",
+    label: "Customer Sentiment Trend",
     value: (d) => <TrendIcon trend={d.callerSentimentChange} />,
   },
   { label: "Language Code", value: (d) => d.lang },

--- a/pca-ui/src/www/src/routes/Dashboard/colours.js
+++ b/pca-ui/src/www/src/routes/Dashboard/colours.js
@@ -1,6 +1,6 @@
 export const colours = {
   Agent: "hsl(45, 100%, 50%)",
-  Caller: "hsl(202, 100%, 50%)",
+  Customer: "hsl(202, 100%, 50%)",
   Silence: "hsl(272, 100%, 50%)",
 };
 

--- a/pca-ui/src/www/src/routes/Search.js
+++ b/pca-ui/src/www/src/routes/Search.js
@@ -19,7 +19,7 @@ const sentimentWhat = [
 ];
 
 const sentimentWho = [
-  { value: "caller", label: "Caller" },
+  { value: "caller", label: "Customer" },
   { value: "agent", label: "Agent" },
 ];
 
@@ -81,7 +81,7 @@ function Search({ setAlert }) {
     <>
       <h3>Search</h3>
       <Form className="mb-5">
-        <Form.Group className="mb-4">
+        <Form.Group className="mb-5">
           <Form.Label>
             <h5>Language Code</h5>
           </Form.Label>
@@ -109,7 +109,7 @@ function Search({ setAlert }) {
           </Button>
         </Form.Group>
 
-        <Form.Group className="mb-4">
+        <Form.Group className="mb-5">
           <Form.Label>
             <h5>Date Range</h5>
           </Form.Label>
@@ -134,7 +134,7 @@ function Search({ setAlert }) {
           </Button>
         </Form.Group>
 
-        <Form.Group className="mb-4">
+        <Form.Group className="mb-5">
           <Form.Label>
             <h5>Sentiment</h5>
           </Form.Label>
@@ -189,7 +189,7 @@ function Search({ setAlert }) {
           </Button>
         </Form.Group>
 
-        <Form.Group className="mb-4">
+        <Form.Group className="mb-5">
           <Form.Label>
             <h5>Entities</h5>
           </Form.Label>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Display Customer/Agent label based on the labels in the API.
Previously, the UI held it's own state matching the speaker channel to the label (Agent/Caller). This PR updates the UI to use the labels provided by the API.

The UI previously used _Caller_ instead of _Customer_. Now, the UI displays the _Customer_ label, as provided in the API response.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
