### PR TITLE
Improve display at different widths

### DIFF
--- a/pca-ui/src/www/src/routes/Dashboard/dashboard.css
+++ b/pca-ui/src/www/src/routes/Dashboard/dashboard.css
@@ -2,15 +2,15 @@
   background-color: var(--highlight-colour);
 }
 
-.charts.charts {
+.charts {
   min-width: clamp(400px, 50% ,600px);
-  flex: 2;
+  flex: 2 2 500px;
 }
 
-.transcribe-col.transcribe-col {
+.transcribe-col {
   flex: 1 1 250px;
 
 }
 .call-details-col {
-  flex: 1;
+  flex: 1 1 250px;
 }

--- a/pca-ui/src/www/src/routes/Dashboard/index.js
+++ b/pca-ui/src/www/src/routes/Dashboard/index.js
@@ -180,8 +180,8 @@ function Dashboard({ setAlert }) {
           Swap Agent/Caller
         </Button>
       </div>
-      <div className="d-flex  gap-2 flex-wrap flex-lg-nowrap">
-        <Card className="call-details-col flex-fill flex-lg-nofill">
+      <div className="d-flex gap-2 flex-wrap flex-lg-nowrap">
+        <Card className="call-details-col">
           <Card.Header>Call Details</Card.Header>
           <Card.Body>
             <Row>
@@ -199,7 +199,7 @@ function Dashboard({ setAlert }) {
             </Row>
           </Card.Body>
         </Card>
-        <Card className="transcribe-col flex-lg-nofill ">
+        <Card className="transcribe-col">
           <Card.Header>Transcribe Details</Card.Header>
           <Card.Body>
             <Row>
@@ -217,7 +217,7 @@ function Dashboard({ setAlert }) {
             </Row>
           </Card.Body>
         </Card>
-        <Card className="charts flex-lg-nofill">
+        <Card className="charts">
           <Card.Body>
             <Row>
               <Col>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR updates the call detail page styling to better use the space at different widths.

The container is at max 1300px wide. The chart aims to take half of this width. The remaining width is split between the two columns.

When there's not enough space to display all three columns comfortably, the cards wrap onto separate rows

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
