### PR TITLE
Include entirety of day in search

### DIFF
--- a/pca-ui/src/www/src/routes/Search.js
+++ b/pca-ui/src/www/src/routes/Search.js
@@ -56,8 +56,11 @@ function Search({ setAlert }) {
   const handleDates = (dates) => {
     const [start, end] = dates;
 
-    handleQueryInput(new Date(start).getTime(), "timestampFrom");
-    handleQueryInput(new Date(end).getTime(), "timestampTo");
+    const timestampFrom = new Date(start).getTime();
+    const timestampTo = end ? new Date(end).setUTCHours(23, 59, 59, 999) : null;
+
+    handleQueryInput(timestampFrom, "timestampFrom");
+    handleQueryInput(timestampTo, "timestampTo");
   };
 
   const filterEmptyKeys = (obj) => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously searches specifying a date range would be [start date, enddate)

This PR updates the search logic to include the entirety of the end date, i.e. [start date, end date]

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
