### PR TITLE
Add Security Headers

### DIFF
--- a/pca-ui/cfn/lib/web.template
+++ b/pca-ui/cfn/lib/web.template
@@ -72,6 +72,7 @@ Resources:
           TargetOriginId: S3
           ViewerProtocolPolicy: redirect-to-https
           DefaultTTL: 60
+          ResponseHeadersPolicyId: !Ref ResponseHeaders
         DefaultRootObject: index.html
         Enabled: true
         Logging:
@@ -86,6 +87,34 @@ Resources:
           - ErrorCode: 403
             ResponseCode: 200
             ResponsePagePath: /index.html
+
+  ResponseHeaders:
+    Type: AWS::CloudFront::ResponseHeadersPolicy
+    Properties:
+      ResponseHeadersPolicyConfig: 
+        Name: !Sub "${AWS::StackName}-SecurityHeaders"
+        SecurityHeadersConfig:
+            ContentSecurityPolicy: 
+              ContentSecurityPolicy: !Sub "default-src 'none'; img-src 'self' data:; script-src 'self'; style-src 'self'; object-src 'none'; connect-src 'self' https://*.execute-api.${AWS::Region}.amazonaws.com https://*.auth.${AWS::Region}.amazoncognito.com; font-src data:;"
+              Override: True
+            ContentTypeOptions:               
+              Override: True
+            FrameOptions: 
+              FrameOption: DENY
+              Override: True
+            ReferrerPolicy: 
+              ReferrerPolicy: same-origin
+              Override: True
+            StrictTransportSecurity: 
+              AccessControlMaxAgeSec: 63072000
+              IncludeSubdomains: True
+              Override: True
+              Preload: True
+            XSSProtection: 
+              ModeBlock: True
+              Override: True
+              Protection: True
+
 
 Outputs:
   Uri:

--- a/pca-ui/src/www/.env
+++ b/pca-ui/src/www/.env
@@ -1,0 +1,1 @@
+INLINE_RUNTIME_CHUNK=false


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add Security Headers to web app

* Add CloudFront response headers resource
* Change the React App build to not inline the initial script.


Ideally I would have liked to specify the exact API GW and Cognito URLs in the CSP. Unfortunately this creates a mess of circular dependencies between the `cognito`, `web` and `api` templates. I couldn't see a simple way to untangle it.
Ideas on how to do so are very welcome.

The new `.env` file is required to configure the build process of the react app. The content security policy prevents the execution of inline scripts. By default part of the react app is inlined into the html. This is blocked by the CSP. The solution is to use the `INLINE_RUNTIME_CHUNK` env var to avoid inlining the runtime chunk.

Adding the CSP is still a win regardless.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
