### PR TITLE
Allow inline styles

### DIFF
--- a/pca-ui/cfn/lib/web.template
+++ b/pca-ui/cfn/lib/web.template
@@ -102,7 +102,7 @@ Resources:
         Name: !Sub "${AWS::StackName}-SecurityHeaders"
         SecurityHeadersConfig:
             ContentSecurityPolicy: 
-              ContentSecurityPolicy: !Sub "default-src 'none'; img-src 'self' https://${DataBucket}.s3.amazonaws.com data:; script-src 'self'; style-src 'self'; object-src 'none'; connect-src 'self' https://*.execute-api.${AWS::Region}.amazonaws.com https://*.auth.${AWS::Region}.amazoncognito.com; font-src data:;  media-src https://${AudioBucket}.s3.amazonaws.com;"
+              ContentSecurityPolicy: !Sub "default-src 'none'; img-src 'self' https://${DataBucket}.s3.amazonaws.com data:; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; connect-src 'self' https://*.execute-api.${AWS::Region}.amazonaws.com https://*.auth.${AWS::Region}.amazoncognito.com; font-src data:;  media-src https://${AudioBucket}.s3.amazonaws.com;"
               Override: True
             ContentTypeOptions:               
               Override: True


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Allow inline styles in the CSP.

This PR adds a new `unsafe-inline` rule to the Content Security Policy `style-src` directive.
Certain dependencies we use have inline styles, or CSS in JS. The alternatives to `unsafe-inline` are using a nonce, or a hash.

It's not possible to use a nonce in our architecture, as we can't modify the CSP header each request, nor the html.
The other alternative is to specify the hash of the offending nodes. I've attempted this, but I've not had much luck and decided to time cap it.

In retrospective, the best approach would be to avoid using these dependencies. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
