### PR TITLE
Add manifest src to csp

### DIFF
--- a/pca-ui/cfn/lib/web.template
+++ b/pca-ui/cfn/lib/web.template
@@ -102,7 +102,7 @@ Resources:
         Name: !Sub "${AWS::StackName}-SecurityHeaders"
         SecurityHeadersConfig:
             ContentSecurityPolicy: 
-              ContentSecurityPolicy: !Sub "default-src 'none'; img-src 'self' https://${DataBucket}.s3.amazonaws.com data:; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; connect-src 'self' https://*.execute-api.${AWS::Region}.amazonaws.com https://*.auth.${AWS::Region}.amazoncognito.com; font-src data:;  media-src https://${AudioBucket}.s3.amazonaws.com;"
+              ContentSecurityPolicy: !Sub "default-src 'none'; img-src 'self' https://${DataBucket}.s3.amazonaws.com data:; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; connect-src 'self' https://*.execute-api.${AWS::Region}.amazonaws.com https://*.auth.${AWS::Region}.amazoncognito.com; font-src data:;  media-src https://${AudioBucket}.s3.amazonaws.com; manifest-src 'self';"
               Override: True
             ContentTypeOptions:               
               Override: True


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Specify a `manifest-src` in the content security policy.

Previously, no `manifest-src` value was set. Whilst we don't intent for this app to be a PWA, we do include a basic `manifest.json` file. This PR updates the Content Security Policy to allow loading of the manifest from the same origin.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
