### PR TITLE
Add alternate bucket url to CSP

### DIFF
--- a/pca-ui/cfn/lib/web.template
+++ b/pca-ui/cfn/lib/web.template
@@ -102,7 +102,9 @@ Resources:
         Name: !Sub "${AWS::StackName}-SecurityHeaders"
         SecurityHeadersConfig:
             ContentSecurityPolicy: 
-              ContentSecurityPolicy: !Sub "default-src 'none'; img-src 'self' https://${DataBucket}.s3.amazonaws.com data:; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; connect-src 'self' https://*.execute-api.${AWS::Region}.amazonaws.com https://*.auth.${AWS::Region}.amazoncognito.com; font-src data:;  media-src https://${AudioBucket}.s3.amazonaws.com; manifest-src 'self';"
+            # Cover both S3 URL types for media-src entries as it
+            # varies by region
+              ContentSecurityPolicy: !Sub "default-src 'none'; img-src 'self' https://${DataBucket}.s3.amazonaws.com https://${DataBucket}.s3.${AWS::Region}.amazonaws.com data:; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; connect-src 'self' https://*.execute-api.${AWS::Region}.amazonaws.com https://*.auth.${AWS::Region}.amazoncognito.com; font-src data:;  media-src https://${AudioBucket}.s3.amazonaws.com; manifest-src 'self';"
               Override: True
             ContentTypeOptions:               
               Override: True


### PR DESCRIPTION
The bucket url used to access recordings in the UI differs in format across regions
In us-east-1 it is `https://${AudioBucket}.s3.amazonaws.com`
In other regions it is `https://${AudioBucket}.s3.${AWS::Region}.amazonaws.com`

This commit adds the second format to the content security policy


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
