### PR TITLE
Add alternate bucket url to CSP media src directive

### DIFF
--- a/pca-ui/cfn/lib/web.template
+++ b/pca-ui/cfn/lib/web.template
@@ -104,7 +104,7 @@ Resources:
             ContentSecurityPolicy: 
             # Cover both S3 URL types for media-src entries as it
             # varies by region
-              ContentSecurityPolicy: !Sub "default-src 'none'; img-src 'self' https://${DataBucket}.s3.amazonaws.com https://${DataBucket}.s3.${AWS::Region}.amazonaws.com data:; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; connect-src 'self' https://*.execute-api.${AWS::Region}.amazonaws.com https://*.auth.${AWS::Region}.amazoncognito.com; font-src data:;  media-src https://${AudioBucket}.s3.amazonaws.com; manifest-src 'self';"
+              ContentSecurityPolicy: !Sub "default-src 'none'; img-src 'self' https://${DataBucket}.s3.amazonaws.com https://${DataBucket}.s3.${AWS::Region}.amazonaws.com data:; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; connect-src 'self' https://*.execute-api.${AWS::Region}.amazonaws.com https://*.auth.${AWS::Region}.amazoncognito.com; font-src data:;  media-src https://${AudioBucket}.s3.amazonaws.com https://${AudioBucket}.s3.${AWS::Region}.amazonaws.com; manifest-src 'self';"
               Override: True
             ContentTypeOptions:               
               Override: True


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Further updates the the Content Security Policy

Any S3 bucket URL needs to have both URL forms included in the CSP. This PR adds the alternate form to the `media-src` directive of the CSP

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
