### PR TITLE
Reduce Lambda function failure rate when processing very large audio files.

### DIFF
--- a/pca-server/cfn/lib/bulk.template
+++ b/pca-server/cfn/lib/bulk.template
@@ -20,8 +20,8 @@ Parameters:
 Globals:
   Function:
     Runtime: python3.8
-    MemorySize: 128
-    Timeout: 15
+    MemorySize: 1024
+    Timeout: 60
 
 Resources:
   BulkFilesCount:

--- a/pca-server/cfn/lib/copy-samples.template
+++ b/pca-server/cfn/lib/copy-samples.template
@@ -22,8 +22,8 @@ Parameters:
 Globals:
   Function:
     Runtime: python3.8
-    MemorySize: 128
-    Timeout: 15
+    MemorySize: 1024
+    Timeout: 60
 
 Resources:
 

--- a/pca-server/cfn/lib/pca.template
+++ b/pca-server/cfn/lib/pca.template
@@ -37,8 +37,8 @@ Parameters:
 Globals:
   Function:
     Runtime: python3.8
-    MemorySize: 128
-    Timeout: 15
+    MemorySize: 1024
+    Timeout: 60
 
 Resources:
   FFMPEGLayer:
@@ -126,7 +126,8 @@ Resources:
     Properties:
       CodeUri:  ../../src/pca
       Handler: pca-aws-sf-start-transcribe-job.lambda_handler
-      Timeout: 30
+      EphemeralStorage: 2048
+      Timeout: 300
       Layers:
         - !Ref FFMPEGLayer
         - !Ref Boto3Layer
@@ -141,8 +142,8 @@ Resources:
     Properties:
       CodeUri:  ../../src/pca
       Handler: pca-aws-sf-process-turn-by-turn.lambda_handler
-      MemorySize: 192
-      Timeout: 600
+      MemorySize: 1024
+      Timeout: 900
       Layers:
         - !Ref FFMPEGLayer
         - !Ref MPLLayer
@@ -204,7 +205,6 @@ Resources:
     Properties:
       CodeUri:  ../../src/pca
       Handler: pca-aws-sf-wait-for-transcribe-notification.lambda_handler
-      Timeout: 10
       Environment:
         Variables:
           TableName: !Ref TableName

--- a/pca-server/cfn/lib/pca.template
+++ b/pca-server/cfn/lib/pca.template
@@ -126,7 +126,8 @@ Resources:
     Properties:
       CodeUri:  ../../src/pca
       Handler: pca-aws-sf-start-transcribe-job.lambda_handler
-      EphemeralStorage: 2048
+      EphemeralStorage:
+        Size: 4096
       Timeout: 300
       Layers:
         - !Ref FFMPEGLayer


### PR DESCRIPTION
*Description of changes:*

- Increase multiple PCA server lambda function memory allocation to make functions run faster, and increase timeouts to reduce liklihood of timeouts when processing large audio files. 
- Increase empheral storage for 'StartTranscribeJob' lambda to accomodate S3 download and temp storage of large audio files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
