### PR TITLE
fix #131 - SFProcessTurn causing CREATE_FAILURE and stack rollback. D…

### DIFF
--- a/pca-main-nokendra.template
+++ b/pca-main-nokendra.template
@@ -217,7 +217,7 @@ Parameters:
 
   ffmpegDownloadUrl:
     Type: String
-    Default: https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
+    Default: https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.4-amd64-static.tar.xz
     Description: URL for ffmpeg binary distribution tar file download - see https://www.johnvansickle.com/ffmpeg/
 
   loadSampleAudioFiles:

--- a/pca-main.template
+++ b/pca-main.template
@@ -217,7 +217,7 @@ Parameters:
 
   ffmpegDownloadUrl:
     Type: String
-    Default: https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
+    Default: https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.4-amd64-static.tar.xz
     Description: URL for ffmpeg binary distribution tar file download - see https://www.johnvansickle.com/ffmpeg/
 
   loadSampleAudioFiles:


### PR DESCRIPTION
SFProcessTurn causing CREATE_FAILURE and stack rollback. 

*Issue #, if available:* #131

*Description of changes:*

Default ffmpeg download URL to use smaller earlier build (v4.).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
