### PR TITLE
fix: prevent page from reloading

### DIFF
--- a/pca-ui/src/www/src/routes/Dashboard/index.js
+++ b/pca-ui/src/www/src/routes/Dashboard/index.js
@@ -21,7 +21,6 @@ import { range } from "../../util";
 import { Sentiment } from "../../components/Sentiment";
 import { Tabs, Tab } from "react-bootstrap";
 
-
 const getSentimentTrends = (d, target, labels) => {
   const id = Object.entries(labels).find(([_, v]) => v === target)?.[0];
   if (!id) return {};
@@ -45,7 +44,11 @@ function Dashboard({ setAlert }) {
   const audioElem = useRef();
   const transcriptElem = useRef();
 
-  const { data, error } = useSWR(`/get/${key}`, () => get(key));
+  const { data, error } = useSWR(`/get/${key}`, () => get(key), {
+    revalidateIfStale: false,
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false
+  });
   const isTranscribeCallAnalyticsMode =
     data?.ConversationAnalytics?.SourceInformation[0]?.TranscribeJobInfo
       ?.TranscribeApiType === "analytics";
@@ -202,18 +205,18 @@ function Dashboard({ setAlert }) {
   .flat()
   .reduce((accumulator, item) => ([...accumulator, item.EndTime]),[]);
 
-const onAudioPLayTimeUpdate = () => {
-  let elementEndTime = undefined;
-  for (let i = 0; i < audioEndTimestamps.length; i++) {
-    if (audioElem.current.currentTime < audioEndTimestamps[i]) {
-      elementEndTime = audioEndTimestamps[i];
-      break;
+  const onAudioPLayTimeUpdate = () => {
+    let elementEndTime = undefined;
+    for (let i = 0; i < audioEndTimestamps.length; i++) {
+      if (audioElem.current.currentTime < audioEndTimestamps[i]) {
+        elementEndTime = audioEndTimestamps[i];
+        break;
+      }
     }
-  }
 
-  [...transcriptElem.current.getElementsByClassName('playing')].map(elem => elem.classList?.remove("playing"));
-  transcriptElem.current.querySelector('span[data-end="'+elementEndTime+'"]')?.classList?.add("playing");
-};
+    [...transcriptElem.current.getElementsByClassName('playing')].map(elem => elem.classList?.remove("playing"));
+    transcriptElem.current.querySelector('span[data-end="'+elementEndTime+'"]')?.classList?.add("playing");
+  };
 
   return (
     <Stack direction="vertical" gap={4}>


### PR DESCRIPTION
*Description of changes:*

Updated the ajax call that downloads the call JSON file to NOT re-download the file again for any reason. The three optional reasons are if stale(old tab), if focus changed (clicked out and back into the window), or if network reconnected.

This issue is only visually prevalent on large calls where there is a lag on reload.

Also, I indented the onAudioPLayTimeUpdate function to make it look nicer.

------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
