### PR TITLE
Feature/json trigger

### DIFF
--- a/output_json_structure.md
+++ b/output_json_structure.md
@@ -253,6 +253,7 @@ Present when the source of the conversation is Amazon Transcribe.  A mixture of 
     "TranscribeJobInfo": {
       "TranscriptionJobName": "string",
       "TranscribeApiType": "string",
+      "StreamingSession": "string",
       "CompletionTime": "string",
       "VocabularyName": "string",
       "VocabularyFilter": "string",
@@ -271,8 +272,9 @@ Present when the source of the conversation is Amazon Transcribe.  A mixture of 
 
 | Field                  | Type   | Description                                                  |
 | ---------------------- | ------ | ------------------------------------------------------------ |
-| TranscriptionJobName   | string | The name of the transcription job                            |
+| TranscriptionJobName   | string | The name of the transcription job (audio file input) or the name of the transcription file (transcription file input) |
 | TranscribeApiType      | string | The Transcribe API used, must be one of:  `standard`, `analytics` |
+| StreamingSession       | string | ID for any associated Transcribe Streaming session           |
 | CompletionTime         | string | A timestamp that shows when the job was completed            |
 | VocabularyName         | string | The name of the vocabulary used in the transcription job     |
 | VocabularyFilter       | string | The name and mask method of the vocabulary filter used in the transcription job |

--- a/output_json_structure.md
+++ b/output_json_structure.md
@@ -260,6 +260,7 @@ Present when the source of the conversation is Amazon Transcribe.  A mixture of 
       "MediaSampleRateHertz": "integer",
       "MediaFileUri": "string",
       "MediaOriginalUri": "string",
+      "RedactedTranscript": "boolean",
       "ChannelIdentification": "boolean",
       "AverageWordConfidence": "float",
       "CombinedAnalyticsGraph": "string"
@@ -279,9 +280,10 @@ Present when the source of the conversation is Amazon Transcribe.  A mixture of 
 | MediaSampleRateHertz   | Int    | The sample rate, in Hertz, of the audio track in the input audio |
 | MediaFileUri           | string | The S3 object location of the media file to use during playback, as we may playback an audio-redacted version or a version that has a format unplayable in all browsers with the HTML5 audio control |
 | MediaOriginalUri       | string | The S3 object location of the original input audio file      |
+| RedactedTranscript     | bool   | Indicates that the transcript has been redacted              |
 | ChannelIdentifcation   | bool   | Indicates whether the transcription job used channel- (true) or speaker-separation (false) |
 | AverageWordConfidence  | float  | Percentage value between 0.00 and 1.00 indicating overall word confidence score for this job |
-| CombinedAnalyticsGraph | string | S3 URL for the pre-generated combined Call Analytics chart |
+| CombinedAnalyticsGraph | string | S3 URL for the pre-generated combined Call Analytics chart   |
 
 ### SpeechSegments
 

--- a/pca-main-nokendra.template
+++ b/pca-main-nokendra.template
@@ -73,7 +73,7 @@ Parameters:
 
   InputBucketAudioPlayback:
     Type: String
-    Default: mp3
+    Default: playbackAudio
     Description: Folder that holds the audio files to playback in the browser when original audio cannot be used
 
   InputBucketFailedTranscriptions:
@@ -92,6 +92,13 @@ Parameters:
     Type: String
     Default: originalAudio
     Description: Prefix/Folder that holds the audio files to be ingested into the system
+
+  InputBucketOrigTranscripts:
+    Type: String
+    Default: originalTranscripts
+    Description: >
+      Folder that holds Transcripts from other applications (e.g. Live Call Analytics) that are to be
+      processed as if PCA had processed that audio
 
   MaxSpeakers:
     Type: String
@@ -353,6 +360,7 @@ Metadata:
               Parameters:
                   - InputBucketFailedTranscriptions
                   - InputBucketRawAudio
+                  - InputBucketOrigTranscripts
                   - InputBucketAudioPlayback
                   - OutputBucketParsedResults
                   - OutputBucketTranscribeResults
@@ -503,6 +511,7 @@ Resources:
           - !Ref InputBucket
           - !Ref InputBucketName        
         InputBucketRawAudio: !Ref InputBucketRawAudio
+        InputBucketOrigTranscripts: !Ref InputBucketOrigTranscripts
         MaxSpeakers: !Ref MaxSpeakers
         MinSentimentNegative: !Ref MinSentimentNegative
         MinSentimentPositive: !Ref MinSentimentPositive
@@ -596,6 +605,10 @@ Outputs:
   InputBucketPrefix:
     Description: S3 Bucket prefix/folder for uploading input audio files
     Value: !Ref InputBucketRawAudio
+
+  InputBucketTranscriptPrefix:
+    Description: S3 Bucket prefix/folder for uploading input transcripts
+    Value: !Ref InputBucketOrigTranscripts
 
   OutputBucket:
     Description: S3 Bucket where Transcribe output files are delivered

--- a/pca-main.template
+++ b/pca-main.template
@@ -37,7 +37,7 @@ Parameters:
 
   ComprehendLanguages:
     Type: String
-    Default: en | es | fr | de | it | pt | ar | hi | ja | ko | zh | zh-TW
+    Default: de | en | es | it | pt | fr | ja | ko | hi | ar | zh | zh-TW
     Description: Languages supported by Comprehend's standard calls, separated by " | "
 
   ContentRedactionLanguages:

--- a/pca-main.template
+++ b/pca-main.template
@@ -73,7 +73,7 @@ Parameters:
 
   InputBucketAudioPlayback:
     Type: String
-    Default: mp3
+    Default: playbackAudio
     Description: Folder that holds the audio files to playback in the browser when original audio cannot be used
 
   InputBucketFailedTranscriptions:
@@ -92,6 +92,13 @@ Parameters:
     Type: String
     Default: originalAudio
     Description: Prefix/Folder that holds the audio files to be ingested into the system
+
+  InputBucketOrigTranscripts:
+    Type: String
+    Default: originalTranscripts
+    Description: >
+      Folder that holds Transcripts from other applications (e.g. Live Call Analytics) that are to be
+      processed as if PCA had processed that audio
 
   MaxSpeakers:
     Type: String
@@ -355,6 +362,7 @@ Metadata:
               Parameters:
                   - InputBucketFailedTranscriptions
                   - InputBucketRawAudio
+                  - InputBucketOrigTranscripts
                   - InputBucketAudioPlayback
                   - OutputBucketParsedResults
                   - OutputBucketTranscribeResults
@@ -635,6 +643,7 @@ Resources:
           - !Ref InputBucket
           - !Ref InputBucketName        
         InputBucketRawAudio: !Ref InputBucketRawAudio
+        InputBucketOrigTranscripts: !Ref InputBucketOrigTranscripts
         MaxSpeakers: !Ref MaxSpeakers
         MinSentimentNegative: !Ref MinSentimentNegative
         MinSentimentPositive: !Ref MinSentimentPositive
@@ -742,6 +751,10 @@ Outputs:
   InputBucketPrefix:
     Description: S3 Bucket prefix/folder for uploading input audio files
     Value: !Ref InputBucketRawAudio
+
+  InputBucketTranscriptPrefix:
+    Description: S3 Bucket prefix/folder for uploading input transcripts
+    Value: !Ref InputBucketOrigTranscripts
 
   OutputBucket:
     Description: S3 Bucket where Transcribe output files are delivered

--- a/pca-server/cfn/lib/pca-definition.json
+++ b/pca-server/cfn/lib/pca-definition.json
@@ -12,7 +12,7 @@
           "Next": "TranscribeAudio"
         }
       ],
-      "Default": "Success"
+      "Default": "ProcessTranscriptHeader"
     },
     "TranscribeAudio": {
       "Comment": "Sends the file in S3 for Transcription",
@@ -78,6 +78,16 @@
       "Comment": "Creates header information based upon the Transcribe job",
       "Type": "Task",
       "Resource": "${SFExtractJobHeaderArn}",
+      "Retry": [{
+          "IntervalSeconds": 5,
+          "ErrorEquals": ["Lambda.Unknown"]
+      }],
+      "Next": "ProcessTranscription"
+    },
+    "ProcessTranscriptHeader": {
+      "Comment": "Creates header information based upon what's available in a transcript file",
+      "Type": "Task",
+      "Resource": "${SFExtractTranscriptHeaderArn}",
       "Retry": [{
           "IntervalSeconds": 5,
           "ErrorEquals": ["Lambda.Unknown"]

--- a/pca-server/cfn/lib/pca-definition.json
+++ b/pca-server/cfn/lib/pca-definition.json
@@ -1,7 +1,19 @@
 {
   "Comment": "Post-Call Analytics Workflow with Transcribe and Comprehend",
-  "StartAt": "TranscribeAudio",
+  "StartAt": "CheckFileType?",
   "States": {
+    "CheckFileType?": {
+      "Type": "Choice",
+      "Comment": "Picks the correct pathway for audio and json files",
+      "Choices": [
+        {
+          "Variable": "$.inputType",
+          "StringEquals": "audio",
+          "Next": "TranscribeAudio"
+        }
+      ],
+      "Default": "Success"
+    },
     "TranscribeAudio": {
       "Comment": "Sends the file in S3 for Transcription",
       "Type": "Task",
@@ -52,7 +64,7 @@
         {
           "Variable": "$.transcribeStatus",
           "StringEquals": "COMPLETED",
-          "Next": "ProcessTranscription"
+          "Next": "ProcessJobHeader"
         },
         {
           "Variable": "$.transcribeStatus",
@@ -61,6 +73,16 @@
         }
       ],
       "Default": "TranscriptionFailed"
+    },
+    "ProcessJobHeader": {
+      "Comment": "Creates header information based upon the Transcribe job",
+      "Type": "Task",
+      "Resource": "${SFExtractJobHeaderArn}",
+      "Retry": [{
+          "IntervalSeconds": 5,
+          "ErrorEquals": ["Lambda.Unknown"]
+      }],
+      "Next": "ProcessTranscription"
     },
     "ProcessTranscription": {
       "Comment": "Takes the output from Transcribe and creates the initial results processing",

--- a/pca-server/cfn/lib/pca.template
+++ b/pca-server/cfn/lib/pca.template
@@ -155,6 +155,23 @@ Resources:
         - arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess
         - arn:aws:iam::aws:policy/AmazonS3FullAccess
 
+  SFExtractTranscriptHeader:
+    Type: "AWS::Serverless::Function"
+    Properties:
+      CodeUri:  ../../src/pca
+      Handler: pca-aws-sf-extract-transcript-header.lambda_handler
+      MemorySize: 1024
+      Timeout: 900
+      Layers:
+        - !Ref Boto3Layer
+        - !Ref FFMPEGLayer
+      Environment:
+        Variables:
+          AWS_DATA_PATH: "/opt/models"
+      Policies:
+        - arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+
   SFProcessTurn:
     Type: "AWS::Serverless::Function"
     Properties:
@@ -264,6 +281,7 @@ Resources:
                 Action: lambda:InvokeFunction
                 Resource:
                   - !GetAtt SFExtractJobHeader.Arn
+                  - !GetAtt SFExtractTranscriptHeader.Arn
                   - !GetAtt SFProcessTurn.Arn
                   - !GetAtt SFStartTranscribeJob.Arn
                   - !GetAtt SFAwaitNotification.Arn
@@ -293,6 +311,7 @@ Resources:
       DefinitionS3Location: ./pca-definition.json
       DefinitionSubstitutions:
         SFExtractJobHeaderArn: !GetAtt SFExtractJobHeader.Arn
+        SFExtractTranscriptHeaderArn: !GetAtt SFExtractTranscriptHeader.Arn
         SFProcessTurnArn: !GetAtt SFProcessTurn.Arn
         SFStartTranscribeJobArn: !GetAtt SFStartTranscribeJob.Arn
         SFAwaitNotificationArn: !GetAtt SFAwaitNotification.Arn

--- a/pca-server/cfn/lib/pca.template
+++ b/pca-server/cfn/lib/pca.template
@@ -138,6 +138,23 @@ Resources:
           AWS_DATA_PATH: "/opt/models"
       Role: !GetAtt TranscribeLambdaRole.Arn
 
+  SFExtractJobHeader:
+    Type: "AWS::Serverless::Function"
+    Properties:
+      CodeUri:  ../../src/pca
+      Handler: pca-aws-sf-extract-job-header.lambda_handler
+      MemorySize: 1024
+      Timeout: 900
+      Layers:
+        - !Ref Boto3Layer
+      Environment:
+        Variables:
+          AWS_DATA_PATH: "/opt/models"
+      Policies:
+        - arn:aws:iam::aws:policy/AmazonTranscribeReadOnlyAccess
+        - arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+
   SFProcessTurn:
     Type: "AWS::Serverless::Function"
     Properties:
@@ -246,6 +263,7 @@ Resources:
               - Effect: Allow
                 Action: lambda:InvokeFunction
                 Resource:
+                  - !GetAtt SFExtractJobHeader.Arn
                   - !GetAtt SFProcessTurn.Arn
                   - !GetAtt SFStartTranscribeJob.Arn
                   - !GetAtt SFAwaitNotification.Arn
@@ -274,6 +292,7 @@ Resources:
       StateMachineName: !Ref StepFunctionName
       DefinitionS3Location: ./pca-definition.json
       DefinitionSubstitutions:
+        SFExtractJobHeaderArn: !GetAtt SFExtractJobHeader.Arn
         SFProcessTurnArn: !GetAtt SFProcessTurn.Arn
         SFStartTranscribeJobArn: !GetAtt SFStartTranscribeJob.Arn
         SFAwaitNotificationArn: !GetAtt SFAwaitNotification.Arn

--- a/pca-server/cfn/lib/trigger.template
+++ b/pca-server/cfn/lib/trigger.template
@@ -22,6 +22,10 @@ Parameters:
     Type: AWS::SSM::Parameter::Value<String>
     Default: InputBucketRawAudio
     
+  InputBucketOrigTranscripts:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: InputBucketOrigTranscripts
+
   StepFunctionName:
     Type: AWS::SSM::Parameter::Value<String>
     Default: StepFunctionName
@@ -112,12 +116,22 @@ Resources:
         Variables:
           StackName: !Ref AWS::StackName
 
-  ConfigureBucket:
+  ConfigureBucketAudioFile:
     Type: "AWS::CloudFormation::CustomResource"
     Properties:
       ServiceToken: !GetAtt ConfigureBucketFunction.Arn
       BucketName: !Ref InputBucketName
       Prefix: !Ref InputBucketRawAudio
+      LambdaArn: !GetAtt FileDropTrigger.Arn
+
+  ConfigureBucketTranscriptFile:
+    Type: "AWS::CloudFormation::CustomResource"
+    DependsOn:
+      - ConfigureBucketAudioFile
+    Properties:
+      ServiceToken: !GetAtt ConfigureBucketFunction.Arn
+      BucketName: !Ref InputBucketName
+      Prefix: !Ref InputBucketOrigTranscripts
       LambdaArn: !GetAtt FileDropTrigger.Arn
 
   TranscribeEventbridge:

--- a/pca-server/src/pca/pca-aws-file-drop-trigger.py
+++ b/pca-server/src/pca/pca-aws-file-drop-trigger.py
@@ -7,6 +7,7 @@ and the configured settings can be overridden - existing jobs will be properly c
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
+from pathlib import Path
 import json
 import urllib.parse
 import boto3
@@ -42,6 +43,38 @@ def get_invalid_mime_type(filename):
     return mime_type
 
 
+def verify_transcribe_file(bucket, key):
+    """
+    Loads in the specified JSON file and validates if it is an Amazon Transcribe output file
+
+    :param bucket: S3 bucket holding the JSON file
+    :param key: Location of the JSON file in the S3 bucket
+    :return: Flag indicating if this file is an Amazon Transcribe file
+    """
+
+    # Download our JSON file to local storage
+    transcribe_file = False
+    inputFilename = TMP_DIR + key.split('/')[-1]
+    s3Client = boto3.client('s3')
+    s3Client.download_file(bucket, key, inputFilename)
+
+    # Load the JSON file into memory
+    json_filepath = Path(inputFilename)
+    asr_output = json.load(open(json_filepath.absolute(), "r", encoding="utf-8"))
+
+    # Standard Transcribe should have a ["results"]["transcripts"] line
+    if "results" in asr_output:
+        if "transcripts" in asr_output["results"]:
+            transcribe_file = True
+    elif "Transcript" in asr_output and "LanguageCode" in asr_output:
+        transcribe_file = True
+
+    # Remove our temporary file in case of Lambda container re-use
+    pcacommon.remove_temp_file(inputFilename)
+
+    return transcribe_file
+
+
 def lambda_handler(event, context):
     # Load our configuration
     cf.loadConfiguration()
@@ -56,7 +89,6 @@ def lambda_handler(event, context):
     if len(key_filename) == 0:
         # Just a folder, no object - silently quit
         final_message = f"Folder creation event at \'{key}\', no object to process"
-        print(final_message)
     else:
         # Validate that the object exists
         try:
@@ -67,42 +99,73 @@ def lambda_handler(event, context):
                 'Error getting object {} from bucket {}. Make sure they exist and your bucket is in the same region as this function.'.format(
                     key, bucket))
 
-        # Download our object to local file storage
-        local_filename = TMP_DIR + key.split('/')[-1]
-        s3_client = boto3.client('s3')
-        s3_client.download_file(bucket, key, local_filename)
-
-        # Get some file metadata to see what kind of file this actually is
-        invalid_mime = get_invalid_mime_type(local_filename)
-        pcacommon.remove_temp_file(local_filename)
-        if invalid_mime is not None:
-            # File metadata contains at least one banned tag
-            final_message = f"File \'{key.split('/')[-1]}\' is not processable by PCA: {invalid_mime}"
-            print(final_message)
+        if key.startswith(cf.appConfig[cf.CONF_PREFIX_INPUT_TRANSCRIPTS]):
+            # This came from the transcript bucket, not the audio bucket
+            if key.endswith(".json"):
+                # Currently we only process Transcribe JSON files
+                if verify_transcribe_file(bucket, key):
+                    # Looks like a Transcribe file - start the workflow
+                    invoke_step_function(bucket, key, "transcript")
+                    final_message = f"Post-call analytics workflow for file {key} successfully started."
+                else:
+                    # Not a Transcribe file - possibly a CTR file, but regardless we can't process it here
+                    final_message = f"File \'{key.split('/')[-1]}\' is not processable by PCA: Transcribe JSON files only"
+            else:
+                final_message = f"File \'{key.split('/')[-1]}\' is not processable by PCA: Transcribe JSON files only"
         else:
-            # File looks good - go find our Step Function
-            ourStepFunction = cf.appConfig[cf.COMP_SFN_NAME]
-            sfnClient = boto3.client('stepfunctions')
-            sfnMachinesResult = sfnClient.list_state_machines(maxResults=1000)
-            sfnArnList = list(filter(lambda x: x["stateMachineArn"].endswith(ourStepFunction), sfnMachinesResult["stateMachines"]))
-            if sfnArnList == []:
-                # Doesn't exist
-                raise Exception(
-                    'Cannot find configured Step Function \'{}\' in the AWS account in this region - cannot begin workflow.'.format(ourStepFunction))
-            sfnArn = sfnArnList[0]['stateMachineArn']
+            # Download our object to local file storage
+            local_filename = TMP_DIR + key.split('/')[-1]
+            s3_client = boto3.client('s3')
+            s3_client.download_file(bucket, key, local_filename)
 
-            # Trigger a new Step Function execution
-            parameters = '{\n  \"bucket\": \"' + bucket + '\",\n' +\
-                         '  \"key\": \"' + key + '\"\n' +\
-                         '}'
-            sfnClient.start_execution(stateMachineArn = sfnArn, input = parameters)
-            final_message = f"Post-call analytics workflow for file {key} successfully started."
+            # Get some file metadata to see what kind of file this actually is
+            invalid_mime = get_invalid_mime_type(local_filename)
+            pcacommon.remove_temp_file(local_filename)
+            if invalid_mime is not None:
+                # File metadata contains at least one banned tag
+                final_message = f"File \'{key.split('/')[-1]}\' is not processable by PCA: {invalid_mime}"
+            else:
+                # File looks good - go find our Step Function
+                invoke_step_function(bucket, key, "audio")
+                final_message = f"Post-call analytics workflow for file {key} successfully started."
 
     # Return our final message
+    print(final_message)
     return {
         'statusCode': 200,
         'body': json.dumps(final_message)
     }
+
+
+def invoke_step_function(bucket, key, file_type):
+    """
+    Attempts to invoke a new Step Function instance to start to process this file.  As well as the file
+    location it also passes info to the Step Function about the type of file that triggered it.
+
+    :param bucket: Bucket holding the input trigger file
+    :param key: Key of for the input trigger file
+    :param file_type: The type of file, either "audio" or "transcript"
+    """
+    ourStepFunction = cf.appConfig[cf.COMP_SFN_NAME]
+    sfnClient = boto3.client('stepfunctions')
+    sfnMachinesResult = sfnClient.list_state_machines(maxResults=1000)
+
+    sfnArnList = list(
+        filter(lambda x: x["stateMachineArn"].endswith(ourStepFunction), sfnMachinesResult["stateMachines"]))
+    if sfnArnList == []:
+        # Doesn't exist
+        raise Exception(
+            'Cannot find configured Step Function \'{}\' in the AWS account in this region - cannot begin workflow.'.format(
+                ourStepFunction))
+
+    # Trigger a new Step Function execution
+    sfnArn = sfnArnList[0]['stateMachineArn']
+    parameters = '{\n  \"bucket\": \"' + bucket + '\",\n' + \
+                 '  \"key\": \"' + key + '\",\n' + \
+                 '  \"inputType\": \"' + file_type + '\"\n' + \
+                 '}'
+    sfnClient.start_execution(stateMachineArn=sfnArn, input=parameters)
+
 
 # Main entrypoint
 if __name__ == "__main__":
@@ -113,14 +176,16 @@ if __name__ == "__main__":
                     "s3SchemaVersion": "1.0",
                     "configurationId": "eca58aa9-dd2b-4405-94d5-d5fba7fd0a16",
                     "bucket": {
-                        "name": "ak-cci-support",
+                        "name": "ak-cci-input",
                         "ownerIdentity": {
                             "principalId": "A39I0T5T4Z0PZJ"
                         },
                         "arn": "arn:aws:s3:::ajk-call-analytics-demo"
                     },
                     "object": {
-                        "key": "PFG/IMG_2346.jpeg.mp3",
+                        # "key": "originalTranscripts/redacted-Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav.json",
+                        # "key": "originalTranscripts/Auto1_GUID_001_AGENT_AndrewK_DT2022-03-20T07-55-51.wav.json",
+                        "key": "originalTranscripts/0000342e-4064-49a7-946c-c7b4fe96489d.wav_metadata.json",
                         "size": 963023,
                         "eTag": "8588ee73ae57d72c072f4bc401627724",
                         "sequencer": "005E99B1F567D61004"
@@ -129,4 +194,27 @@ if __name__ == "__main__":
             }
         ]
     }
+    # event = {
+    #     "Records": [
+    #         {
+    #             "s3": {
+    #                 "s3SchemaVersion": "1.0",
+    #                 "configurationId": "eca58aa9-dd2b-4405-94d5-d5fba7fd0a16",
+    #                 "bucket": {
+    #                     "name": "ak-cci-support",
+    #                     "ownerIdentity": {
+    #                         "principalId": "A39I0T5T4Z0PZJ"
+    #                     },
+    #                     "arn": "arn:aws:s3:::ajk-call-analytics-demo"
+    #                 },
+    #                 "object": {
+    #                     "key": "PFG/IMG_2346.jpeg.mp3",
+    #                     "size": 963023,
+    #                     "eTag": "8588ee73ae57d72c072f4bc401627724",
+    #                     "sequencer": "005E99B1F567D61004"
+    #                 }
+    #             }
+    #         }
+    #     ]
+    # }
     lambda_handler(event, "")

--- a/pca-server/src/pca/pca-aws-sf-ctr-genesys.py
+++ b/pca-server/src/pca/pca-aws-sf-ctr-genesys.py
@@ -669,7 +669,8 @@ def lambda_handler(event, context):
 
         # Finished all updates - write results back to our interim location
         if not OFFLINE_MODE:
-            pca_results.write_results_to_s3(cf.appConfig[cf.CONF_S3BUCKET_OUTPUT], event["interimResultsFile"])
+            pca_results.write_results_to_s3(bucket=cf.appConfig[cf.CONF_S3BUCKET_OUTPUT],
+                                            object_key=event["interimResultsFile"])
 
     # Return our original event data for the next step
     return event

--- a/pca-server/src/pca/pca-aws-sf-extract-job-header.py
+++ b/pca-server/src/pca/pca-aws-sf-extract-job-header.py
@@ -1,0 +1,164 @@
+"""
+This python function is part of the main processing workflow.  It will read in all of the relevant
+Transcribe job header information and write out some partial results before passing control to the
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+from pcaresults import PCAResults, TranscribeJobInfo
+import pcaconfiguration as cf
+import copy
+import boto3
+
+
+def populate_job_info(transcribe_info, job_info, api_mode):
+    """
+    Updates the PCAResults data for Transcribe with data from the Transcribe Job Info.  Note, some of
+    this may be overwritten later by other processes; e.g. when the word confidence average score is
+    calculated, or it we change the playback URI
+
+    :param transcribe_info: Transcribe data block within our PCAResults block
+    :param job_info: Output from Transcribe's job information API call
+    :param api_mode: The operational mode used for Transcribe (e.g. Standard or Anaytics)
+    """
+    # Some fields we pick off the basic job info
+    transcribe_info.api_mode = api_mode
+    transcribe_info.completion_time = str(job_info["CompletionTime"])
+    transcribe_info.media_format = job_info["MediaFormat"]
+    transcribe_info.media_sample_rate = int(job_info["MediaSampleRateHertz"])
+    transcribe_info.media_original_uri = job_info["Media"]["MediaFileUri"]
+    transcribe_info.media_playback_uri = transcribe_info.media_original_uri
+
+    # Vocabulary name is optional
+    if "VocabularyName" in job_info["Settings"]:
+        transcribe_info.custom_vocab_name = job_info["Settings"]["VocabularyName"]
+
+    # Vocabulary filter is optional
+    if "VocabularyFilterName" in job_info["Settings"]:
+        transcribe_info.vocab_filter_name = job_info["Settings"]["VocabularyFilterName"]
+        transcribe_info.vocab_filter_method = job_info["Settings"]["VocabularyFilterMethod"]
+
+    # Some fields are different in the job-status depending upon which API we were using
+    if api_mode == cf.API_ANALYTICS:
+        transcribe_info.transcribe_job_name = job_info["CallAnalyticsJobName"]
+        transcribe_info.channel_identification = 1
+    else:
+        transcribe_info.transcribe_job_name = job_info["TranscriptionJobName"]
+        transcribe_info.channel_identification = int(job_info["Settings"]["ChannelIdentification"])
+
+
+def load_transcribe_job_header(event):
+    """
+    Loads in the job status for the job named in input event.  The event will inform the method which of the
+    Transcribe APIs should be called (e.g. standard or call analytics).  It will exception if the job either
+    doesn't exist or if it is still running.
+
+    :param event: Event info passed down from Step Functions
+    :return: PCAResults() structure that just contains the Transcribe job info
+    """
+    # Load in the Amazon Transcribe job header information, ensuring that the job has completed
+    transcribe_client = boto3.client("transcribe")
+    api_mode = event["apiMode"]
+    job_name = event["jobName"]
+    try:
+        is_redacted = False
+        if api_mode == cf.API_STANDARD:
+            # Standard Transcribe job
+            transcribe_job_info = transcribe_client.get_transcription_job(TranscriptionJobName=job_name)["TranscriptionJob"]
+            if "ContentRedaction" in transcribe_job_info:
+                transcript_uri = transcribe_job_info["Transcript"]["RedactedTranscriptFileUri"]
+                is_redacted = True
+            else:
+                transcript_uri = transcribe_job_info["Transcript"]["TranscriptFileUri"]
+        elif api_mode == cf.API_ANALYTICS:
+            # Call Analytics Transcribe job
+            transcribe_job_info = transcribe_client.get_call_analytics_job(CallAnalyticsJobName=job_name)["CallAnalyticsJob"]
+            if "RedactedTranscriptFileUri" in transcribe_job_info["Transcript"]:
+                transcript_uri = transcribe_job_info["Transcript"]["RedactedTranscriptFileUri"]
+                is_redacted = True
+            else:
+                transcript_uri = transcribe_job_info["Transcript"]["TranscriptFileUri"]
+
+    except transcribe_client.exceptions.BadRequestException:
+        assert False, f"Unable to load information for Transcribe job named '{job_name}'."
+
+    # Now take this info data and create the analytics results header info data
+    interim_results = PCAResults()
+    job_results_header = interim_results.get_conv_analytics().get_transcribe_job()
+    populate_job_info(job_results_header, transcribe_job_info, api_mode)
+    job_results_header.redacted_transcript = is_redacted
+
+    # Populate the PCAResults() structure with anything else of use
+    interim_results.analytics.conversationLanguageCode = transcribe_job_info["LanguageCode"]
+
+    # Pass the location of any redacted audio to the next step - it isn't
+    # needed in the results, but the next step in the workflow may need it
+    if "RedactedMediaFileUri" in transcribe_job_info["Media"]:
+        event["redactedMediaFileUri"] = transcribe_job_info["Media"]["RedactedMediaFileUri"]
+
+    # Potentially add some values to our SF event data to pass to the next step
+    event["transcriptUri"] = transcript_uri
+    if "ChannelDefinitions" in transcribe_job_info:
+        event["channelDefinitions"] = transcribe_job_info["ChannelDefinitions"]
+
+    # Return the whole results block
+    return interim_results
+
+
+def lambda_handler(event, context):
+    """
+    Lambda handler entrypoint
+
+    :param event: Step Function input event data
+    :param context: Lambda context (unused)
+    :return:
+    """
+    # Load our configuration data
+    sf_event = copy.deepcopy(event)
+    cf.loadConfiguration()
+    job_name = sf_event["jobName"]
+
+    # We should only be here if the job has completed, so exit quickly if this isn't the case
+    assert sf_event["transcribeStatus"] == "COMPLETED", f"Transcription job '{job_name}' has not yet completed."
+
+    # Load in the job header and get our transcript file location
+    interim_results = load_transcribe_job_header(sf_event)
+
+    # Now write it out to our interim results location
+    json_output_filename = sf_event["transcriptUri"].split("/")[-1]
+    json_output, output_filename = interim_results.write_results_to_s3(object_key=json_output_filename, interim=True)
+    sf_event["interimResultsFile"] = output_filename
+
+    return sf_event
+
+
+# Main entrypoint for testing
+if __name__ == "__main__":
+    # Test event
+    test_event_analytics = {
+        "bucket": "ak-cci-input",
+        "key": "originalAudio/Card2_GUID_102_AGENT_AndrewK_DT_2022-03-22T12-23-49.wav",
+        "inputType": "audio",
+        "jobName": "Card2_GUID_102_AGENT_AndrewK_DT_2022-03-22T12-23-49.wav",
+        "apiMode": "analytics",
+        "transcribeStatus": "COMPLETED"
+    }
+    test_event_stereo = {
+        "bucket": "ak-cci-input",
+        "key": "originalAudio/Auto3_GUID_003_AGENT_BobS_DT_2022-03-21T17-51-51.wav",
+        "inputType": "audio",
+        "jobName": "Auto3_GUID_003_AGENT_BobS_DT_2022-03-21T17-51-51.wav",
+        "apiMode": "standard",
+        "transcribeStatus": "COMPLETED"
+    }
+    test_event_mono = {
+        "bucket": "ak-cci-input",
+        "key": "originalAudio/Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav",
+        "inputType": "audio",
+        "jobName": "Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav",
+        "apiMode": "standard",
+        "transcribeStatus": "COMPLETED"
+    }
+    lambda_handler(test_event_analytics, "")
+    lambda_handler(test_event_stereo, "")
+    lambda_handler(test_event_mono, "")

--- a/pca-server/src/pca/pca-aws-sf-extract-job-header.py
+++ b/pca-server/src/pca/pca-aws-sf-extract-job-header.py
@@ -1,11 +1,12 @@
 """
 This python function is part of the main processing workflow.  It will read in all of the relevant
 Transcribe job header information and write out some partial results before passing control to the
+next step
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
-from pcaresults import PCAResults, TranscribeJobInfo
+from pcaresults import PCAResults
 import pcaconfiguration as cf
 import copy
 import boto3
@@ -23,6 +24,7 @@ def populate_job_info(transcribe_info, job_info, api_mode):
     """
     # Some fields we pick off the basic job info
     transcribe_info.api_mode = api_mode
+    transcribe_info.streaming_mode = False
     transcribe_info.completion_time = str(job_info["CompletionTime"])
     transcribe_info.media_format = job_info["MediaFormat"]
     transcribe_info.media_sample_rate = int(job_info["MediaSampleRateHertz"])

--- a/pca-server/src/pca/pca-aws-sf-extract-transcript-header.py
+++ b/pca-server/src/pca/pca-aws-sf-extract-transcript-header.py
@@ -1,0 +1,210 @@
+"""
+This python function is part of the main processing workflow.  It will generate equivalent values
+for Transcribe job header information from an input Transcribe results file, and then write out some
+partial results before passing control to the next step.  This allow the delivery of transcriptions
+from an external Transcribe Live Call Analytics streaming job
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+from pcaresults import PCAResults
+from datetime import datetime
+from pathlib import Path
+import pcaconfiguration as cf
+import pcacommon
+import boto3
+import json
+import time
+import copy
+
+# Useful constants
+TMP_DIR = "/tmp"
+
+
+def load_transcript_file(transcript_bucket, transcript_path):
+    """
+    Loads the transcription file from its S3 location
+
+    :param transcript_bucket: S3 bucket holding the transcript file
+    :param transcript_path: Full path to the transcript file in the bucket
+    :return: JSON transcript results file
+    """
+    # Download the job JSON results file to a local temp file
+    json_filepath = TMP_DIR + '/' + transcript_path.split("/")[-1]
+
+    # Now download - this has been known to get a "404 HeadObject Not Found",
+    # which makes no sense, so if that happens then re-try in a sec.  Only once.
+    s3Client = boto3.client('s3')
+    try:
+        s3Client.download_file(transcript_bucket, transcript_path, json_filepath)
+    except:
+        time.sleep(3)
+        s3Client.download_file(transcript_bucket, transcript_path, json_filepath)
+
+    # Load in and the JSON file for processing, and set our language codes for the file and Comprehend
+    asr_output = json.load(open(Path(json_filepath).absolute(), "r", encoding="utf-8"))
+
+    # Clean up and return the result
+    pcacommon.remove_temp_file(json_filepath)
+    return asr_output
+
+
+def update_audio_file_metadata(sf_event, interim_results):
+    """
+    Extracts metadata from the associated audio file, such as sample rate and format
+
+    :param sf_event: Step Function input event data
+    :param interim_results:
+    """
+    # First, we need to download the original audio file, which for streaming analytics
+    # will be in the playbackAudio folder, named after the transcript, and will be a WAV
+    ts_info = interim_results.get_conv_analytics().get_transcribe_job()
+    base_filename = (sf_event["key"].split('/')[-1]).split('.json')[0] + '.wav'
+    output_filename = TMP_DIR + "/" + base_filename
+    input_filename = cf.appConfig[cf.CONF_PREFIX_AUDIO_PLAYBACK] + "/" + base_filename
+
+    # Now download and process that audio file
+    try:
+        # Download
+        s3Client = boto3.client('s3')
+        s3Client.download_file(cf.appConfig[cf.CONF_S3BUCKET_INPUT], input_filename, output_filename)
+
+        # Extract some stream-based metadata from the audio file
+        ts_info.media_sample_rate = int(pcacommon.ffprobe_get_stream_entries("stream=sample_rate", output_filename))
+        ts_info.media_format = pcacommon.ffprobe_get_stream_entries("format=format_name", output_filename)
+
+        # Update our audio file locations
+        ts_info.media_original_uri = "s3://" + cf.appConfig[cf.CONF_S3BUCKET_INPUT] + "/" + input_filename
+        ts_info.media_playback_uri = ts_info.media_original_uri
+
+        # Remove any temp tile
+        pcacommon.remove_temp_file(output_filename)
+    except Exception as e:
+        print(e)
+        print(f"Unable to download/process audio file associated with transcript {sf_event['key']}")
+
+
+def create_participant_map(sf_event, asr_output):
+    """
+    Creates a participant/channel map, which is needed in future steps.  Note, we have to assume
+    that the first entry in the JSON transcript's [Participants] block came from channel 0.
+
+    :param sf_event:  Step Function input event data
+    :param asr_output: JSON transcript to be processed
+    """
+    index = 0
+    participant_map = []
+    for participant in asr_output["Participants"]:
+        new_entry = {"ChannelId": index,
+                     "ParticipantRole": participant["ParticipantRole"]}
+        participant_map.append(new_entry)
+        index += 1
+
+    sf_event["channelDefinitions"] = participant_map
+
+
+def create_transcribe_job_header(sf_event, asr_output):
+    """
+    Based on the Step Functions input data and the transcript, generate as much data as possible in the
+    TranscribeJobInfo header block, and some basic analytics entries, so that when the next workflow step
+    tp process the transcript is called it has the same header data from a transcript as is does from an
+    audio file.  This will not be perfect - e.g. entries for Custom Vocabulary or Vacabulary filters simply
+    don't exist in Streaming Analytics files.
+
+    :param sf_event:  Step Function input event data
+    :param asr_output: JSON transcript to be processed
+    :return: Our initial header results to be used by later workflow steps
+    """
+
+    # Mark the Step Functions data with the type of processing
+    # TODO this will have to be more programmatic as we support other Transcribe output formats
+    assert ("ConversationCharacteristics" in asr_output) and ("JobName" not in asr_output),\
+        "Only Transcribe Streaming Analytics transcripts are supported"
+
+    # Add on the event values that we'd expect to have from an audio file
+    # TODO The API mode should streaming analytics, but wait until the UI can cope
+    sf_event["apiMode"] = cf.API_ANALYTICS
+    sf_event["jobName"] = asr_output["SessionId"]
+    sf_event["transcribeStatus"] = asr_output["JobStatus"]
+
+    interim_results = PCAResults()
+    interim_results.analytics.conversationLanguageCode = asr_output["LanguageCode"]
+
+    # Setup the simple [TranscribeJobInfo] data points
+    transcribe_header = interim_results.get_conv_analytics().get_transcribe_job()
+    transcribe_header.streaming_mode = True
+    transcribe_header.completion_time = str(datetime.now())
+    transcribe_header.channel_identification = 1
+    transcribe_header.cummulative_word_conf = 0.0
+
+    # Scan transcript for redacted lines - awkward, as each [PII] block is actually marked as
+    # what it was - e.g [NAME] - so we look for [, as that shouldn't be in the content line
+    pii_lines = list(filter(lambda x: "[" in x["Content"], asr_output["Transcript"]))
+    transcribe_header.redacted_transcript = len(pii_lines) > 0
+
+    # Extract audio metadata from the audio file, which also sets our file S3 locations
+    update_audio_file_metadata(sf_event, interim_results)
+
+    # Create a channel/participant map
+    create_participant_map(sf_event, asr_output)
+
+    # Copy the transcript file to the standard transcript output location
+    copy_transcript_file(sf_event)
+
+    # We don't have a job name - we could re-purpose the filename, but later
+    # lookups using it could read incorrect data.  So go with the stream session
+    transcribe_header.transcribe_job_name = sf_event["key"].split('/')[-1]
+    transcribe_header.streaming_session = asr_output["SessionId"]
+
+    return interim_results
+
+
+def copy_transcript_file(sf_event):
+    """
+    Copies the transcript file from the input bucket to the location in the output bucket
+    and folder that holds the raw transcripts; this will be inside a "liveStreaming", as the
+    other TCA outputs are also inside a subfolder
+
+    :param sf_event: Step Functions event
+    """
+    # Now copy the transcript file to the output folder (where the others all live)
+    s3_client = boto3.resource("s3")
+    source = {"Bucket": cf.appConfig[cf.CONF_S3BUCKET_INPUT], "Key": sf_event["key"]}
+    dest_key = cf.appConfig[cf.CONF_PREFIX_TRANSCRIBE_RESULTS] + "/liveStreaming/" + sf_event["key"].split('/')[-1]
+    s3_client.meta.client.copy(source, cf.appConfig[cf.CONF_S3BUCKET_OUTPUT], dest_key)
+    sf_event["transcriptUri"] = "s3://" + cf.appConfig[cf.CONF_S3BUCKET_OUTPUT] + "/" + dest_key
+
+
+def lambda_handler(event, context):
+    """
+    Lambda handler entrypoint
+
+    :param event: Step Function input event data
+    :param context: Lambda context (unused)
+    :return:
+    """
+    # Load our configuration data
+    sf_event = copy.deepcopy(event)
+    cf.loadConfiguration()
+
+    # Load up our transcript file and create our baseline data
+    asr_output = load_transcript_file(sf_event["bucket"], sf_event["key"])
+    interim_results = create_transcribe_job_header(sf_event, asr_output)
+
+    # Now write it out to our interim results location
+    json_output_filename = sf_event["key"].split("/")[-1]
+    json_output, output_filename = interim_results.write_results_to_s3(object_key=json_output_filename, interim=True)
+    sf_event["interimResultsFile"] = output_filename
+
+    return sf_event
+
+
+# Main entrypoint for testing
+if __name__ == "__main__":
+    # Test event
+    test_event_tca = {
+        "bucket": "ak-cci-input",
+        "key": "originalTranscripts/TCA_GUID_3c7161f7-bebc-4951-9cfb-943af1d3a5f5_CUST_17034816544_AGENT_BabuS_2022-11-22T21-32-52.145Z.json",
+        "inputType": "transcript"
+    }
+    lambda_handler(test_event_tca, "")

--- a/pca-server/src/pca/pca-aws-sf-post-ctr-processing.py
+++ b/pca-server/src/pca/pca-aws-sf-post-ctr-processing.py
@@ -17,11 +17,9 @@ def lambda_handler(event, context):
 
     # Load our configuration data
     cf.loadConfiguration()
-    results_bucket = cf.appConfig[cf.CONF_S3BUCKET_OUTPUT]
 
     # Load in our existing interim CCA results
     pca_results = pcaresults.PCAResults()
-    pca_analytics = pca_results.get_conv_analytics()
     pca_results.read_results_from_s3(cf.appConfig[cf.CONF_S3BUCKET_OUTPUT], event["interimResultsFile"])
 
     # --------- Do any post processing here ----------
@@ -63,6 +61,16 @@ if __name__ == "__main__":
         "transcribeStatus": "COMPLETED",
         "interimResultsFile": "interimResults/redacted-Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav.json"
     }
+    test_stream_tca = {
+        "bucket": "ak-cci-input",
+        "key": "originalTranscripts/TCA_GUID_3c7161f7-bebc-4951-9cfb-943af1d3a5f5_CUST_17034816544_AGENT_BabuS_2022-11-22T21-32-52.145Z.json",
+        "inputType": "transcript",
+        "jobName": "TCA_GUID_3c7161f7-bebc-4951-9cfb-943af1d3a5f5_CUST_17034816544_AGENT_BabuS_2022-11-22T21-32-52.145Z.json",
+        "apiMode": "analytics",
+        "transcribeStatus": "COMPLETED",
+        "interimResultsFile": "interimResults/TCA_GUID_3c7161f7-bebc-4951-9cfb-943af1d3a5f5_CUST_17034816544_AGENT_BabuS_2022-11-22T21-32-52.145Z.json"
+    }
     lambda_handler(test_event_analytics, "")
     lambda_handler(test_event_stereo, "")
     lambda_handler(test_event_mono, "")
+    lambda_handler(test_stream_tca, "")

--- a/pca-server/src/pca/pca-aws-sf-post-ctr-processing.py
+++ b/pca-server/src/pca/pca-aws-sf-post-ctr-processing.py
@@ -27,28 +27,42 @@ def lambda_handler(event, context):
     # --------- Do any post processing here ----------
 
     # Write out back to interim file
-    pca_results.write_results_to_s3(cf.appConfig[cf.CONF_S3BUCKET_OUTPUT], event["interimResultsFile"])
+    pca_results.write_results_to_s3(bucket=cf.appConfig[cf.CONF_S3BUCKET_OUTPUT],
+                                    object_key=event["interimResultsFile"])
 
     return event
 
 
 # Main entrypoint for testing
 if __name__ == "__main__":
-    event = {
+    # Test event
+    test_event_analytics = {
         "bucket": "ak-cci-input",
-        "langCode": "en-US",
-        "transcribeStatus": "COMPLETED",
+        "key": "originalAudio/Card2_GUID_102_AGENT_AndrewK_DT_2022-03-22T12-23-49.wav",
+        "inputType": "audio",
+        "jobName": "Card2_GUID_102_AGENT_AndrewK_DT_2022-03-22T12-23-49.wav",
         "apiMode": "analytics",
-        "key": "originalAudio/006c7659-258e-4adc-a036-df717505e25a.wav",
-        "jobName": "006c7659-258e-4adc-a036-df717505e25a.wav",
-        "interimResultsFile": "interimResults/006c7659-258e-4adc-a036-df717505e25a.wav.json",
-        # "key": "originalAudio/fef9f532-08e0-436c-b0cc-7df991521e96.wav",
-        # "jobName": "fef9f532-08e0-436c-b0cc-7df991521e96.wav",
-        # "interimResultsFile": "interimResults/fef9f532-08e0-436c-b0cc-7df991521e96.wav.json",
-        # "key": "originalAudio/fd4bd0f6-52c2-4fab-97de-8f7518474403.wav",
-        # "jobName": "fd4bd0f6-52c2-4fab-97de-8f7518474403.wav",
-        # "interimResultsFile": "interimResults/fd4bd0f6-52c2-4fab-97de-8f7518474403.wav.json",
-        "telephony": "none",
-        "debug": True
+        "transcribeStatus": "COMPLETED",
+        "interimResultsFile": "interimResults/Card2_GUID_102_AGENT_AndrewK_DT_2022-03-22T12-23-49.wav.json"
     }
-    lambda_handler(event, "")
+    test_event_stereo = {
+        "bucket": "ak-cci-input",
+        "key": "originalAudio/Auto3_GUID_003_AGENT_BobS_DT_2022-03-21T17-51-51.wav",
+        "inputType": "audio",
+        "jobName": "Auto3_GUID_003_AGENT_BobS_DT_2022-03-21T17-51-51.wav",
+        "apiMode": "standard",
+        "transcribeStatus": "COMPLETED",
+        "interimResultsFile": "interimResults/redacted-Auto3_GUID_003_AGENT_BobS_DT_2022-03-21T17-51-51.wav.json"
+    }
+    test_event_mono = {
+        "bucket": "ak-cci-input",
+        "key": "originalAudio/Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav",
+        "inputType": "audio",
+        "jobName": "Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav",
+        "apiMode": "standard",
+        "transcribeStatus": "COMPLETED",
+        "interimResultsFile": "interimResults/redacted-Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav.json"
+    }
+    lambda_handler(test_event_analytics, "")
+    lambda_handler(test_event_stereo, "")
+    lambda_handler(test_event_mono, "")

--- a/pca-server/src/pca/pca-aws-sf-post-processing.py
+++ b/pca-server/src/pca/pca-aws-sf-post-processing.py
@@ -38,20 +38,34 @@ def lambda_handler(event, context):
 
 # Main entrypoint for testing
 if __name__ == "__main__":
-    event = {
+    # Test event
+    test_event_analytics = {
         "bucket": "ak-cci-input",
-        "langCode": "en-US",
-        "transcribeStatus": "COMPLETED",
+        "key": "originalAudio/Card2_GUID_102_AGENT_AndrewK_DT_2022-03-22T12-23-49.wav",
+        "inputType": "audio",
+        "jobName": "Card2_GUID_102_AGENT_AndrewK_DT_2022-03-22T12-23-49.wav",
         "apiMode": "analytics",
-        # "key": "originalAudio/006c7659-258e-4adc-a036-df717505e25a.wav",
-        # "jobName": "006c7659-258e-4adc-a036-df717505e25a.wav",
-        # "interimResultsFile": "interimResults/006c7659-258e-4adc-a036-df717505e25a.wav.json",
-        "key": "originalAudio/fd4bd0f6-52c2-4fab-97de-8f7518474403.wav",
-        "jobName": "fd4bd0f6-52c2-4fab-97de-8f7518474403.wav",
-        "interimResultsFile": "interimResults/fd4bd0f6-52c2-4fab-97de-8f7518474403.wav.json",
-        # "key": "originalAudio/fef9f532-08e0-436c-b0cc-7df991521e96.wav",
-        # "jobName": "fef9f532-08e0-436c-b0cc-7df991521e96.wav",
-        # "interimResultsFile": "interimResults/fef9f532-08e0-436c-b0cc-7df991521e96.wav.json",
-        "telephony": "none"
+        "transcribeStatus": "COMPLETED",
+        "interimResultsFile": "interimResults/Card2_GUID_102_AGENT_AndrewK_DT_2022-03-22T12-23-49.wav.json"
     }
-    lambda_handler(event, "")
+    test_event_stereo = {
+        "bucket": "ak-cci-input",
+        "key": "originalAudio/Auto3_GUID_003_AGENT_BobS_DT_2022-03-21T17-51-51.wav",
+        "inputType": "audio",
+        "jobName": "Auto3_GUID_003_AGENT_BobS_DT_2022-03-21T17-51-51.wav",
+        "apiMode": "standard",
+        "transcribeStatus": "COMPLETED",
+        "interimResultsFile": "interimResults/redacted-Auto3_GUID_003_AGENT_BobS_DT_2022-03-21T17-51-51.wav.json"
+    }
+    test_event_mono = {
+        "bucket": "ak-cci-input",
+        "key": "originalAudio/Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav",
+        "inputType": "audio",
+        "jobName": "Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav",
+        "apiMode": "standard",
+        "transcribeStatus": "COMPLETED",
+        "interimResultsFile": "interimResults/redacted-Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav.json"
+    }
+    lambda_handler(test_event_analytics, "")
+    lambda_handler(test_event_stereo, "")
+    lambda_handler(test_event_mono, "")

--- a/pca-server/src/pca/pca-aws-sf-post-processing.py
+++ b/pca-server/src/pca/pca-aws-sf-post-processing.py
@@ -66,6 +66,16 @@ if __name__ == "__main__":
         "transcribeStatus": "COMPLETED",
         "interimResultsFile": "interimResults/redacted-Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav.json"
     }
+    test_stream_tca = {
+        "bucket": "ak-cci-input",
+        "key": "originalTranscripts/TCA_GUID_3c7161f7-bebc-4951-9cfb-943af1d3a5f5_CUST_17034816544_AGENT_BabuS_2022-11-22T21-32-52.145Z.json",
+        "inputType": "transcript",
+        "jobName": "TCA_GUID_3c7161f7-bebc-4951-9cfb-943af1d3a5f5_CUST_17034816544_AGENT_BabuS_2022-11-22T21-32-52.145Z.json",
+        "apiMode": "analytics",
+        "transcribeStatus": "COMPLETED",
+        "interimResultsFile": "interimResults/TCA_GUID_3c7161f7-bebc-4951-9cfb-943af1d3a5f5_CUST_17034816544_AGENT_BabuS_2022-11-22T21-32-52.145Z.json"
+    }
     lambda_handler(test_event_analytics, "")
     lambda_handler(test_event_stereo, "")
     lambda_handler(test_event_mono, "")
+    lambda_handler(test_stream_tca, "")

--- a/pca-server/src/pca/pca-aws-sf-process-turn-by-turn.py
+++ b/pca-server/src/pca/pca-aws-sf-process-turn-by-turn.py
@@ -1285,7 +1285,7 @@ class TranscribeParser:
                                 stdin=subprocess.DEVNULL)
 
                 # Now upload the output file to the configured playback folder in the main input bucket
-                s3FileKey = cf.appConfig[cf.CONF_PREFIX_MP3_PLAYBACK] + '/' + outputFilename.split('/')[-1]
+                s3FileKey = cf.appConfig[cf.CONF_PREFIX_AUDIO_PLAYBACK] + '/' + outputFilename.split('/')[-1]
                 s3Client.upload_file(outputFilename, cf.appConfig[cf.CONF_S3BUCKET_INPUT], s3FileKey,
                                      ExtraArgs={'ContentType': 'audio/mp3'})
                 self.audioPlaybackUri = "s3://" + cf.appConfig[cf.CONF_S3BUCKET_INPUT] + "/" + s3FileKey
@@ -1353,7 +1353,7 @@ class TranscribeParser:
             s3_object = urlparse(redacted_url)
             s3_client = boto3.resource("s3")
             source = {"Bucket": s3_object.netloc, "Key": s3_object.path[1:]}
-            dest_key = cf.appConfig[cf.CONF_PREFIX_MP3_PLAYBACK] + '/' + redacted_url.split('/')[-1]
+            dest_key = cf.appConfig[cf.CONF_PREFIX_AUDIO_PLAYBACK] + '/' + redacted_url.split('/')[-1]
             s3_client.meta.client.copy(source, cf.appConfig[cf.CONF_S3BUCKET_INPUT], dest_key)
             self.audioPlaybackUri = "s3://" + cf.appConfig[cf.CONF_S3BUCKET_INPUT] + "/" + dest_key
         else:

--- a/pca-server/src/pca/pca-aws-sf-process-turn-by-turn.py
+++ b/pca-server/src/pca/pca-aws-sf-process-turn-by-turn.py
@@ -32,7 +32,6 @@ COMPREHEND_SENTIMENT_SCALER = 5.0
 PII_PLACEHOLDER = "[PII]"
 PII_PLACEHOLDER_MASK = "*" * len(PII_PLACEHOLDER)
 TMP_DIR = "/tmp"
-TEMP_OUTPUT_KEY = "interimResults"
 BAR_CHART_WIDTH = 1.0
 
 
@@ -41,10 +40,10 @@ class TranscribeParser:
     def __init__(self, min_sentiment_pos, min_sentiment_neg, custom_entity_endpoint):
         self.pca_results = PCAResults()
         self.analytics = self.pca_results.get_conv_analytics()
+        self.transcribe_job_info = self.analytics.get_transcribe_job()
         self.speechSegmentList = []
         self.min_sentiment_positive = min_sentiment_pos
         self.min_sentiment_negative = min_sentiment_neg
-        self.transcribeJobInfo = ""
         self.comprehendLanguageCode = ""
         self.headerEntityDict = {}
         self.numWordsParsed = 0
@@ -201,86 +200,70 @@ class TranscribeParser:
         upload the speech segment list as-is, then do the other constructs one by one
         '''
         resultsHeaderInfo = {}
-        analytics = self.analytics
 
         # Ensure our results have the speech segments recorded
         self.pca_results.speech_segments = self.speechSegmentList
 
-        # -----------------------------
-        # Conversational Analytics data
-        # -----------------------------
-
         # Sentiment Trends
         for speaker in range(self.maxSpeakerIndex + 1):
             full_name = self.pca_results.get_speaker_prefix(True) + str(speaker)
-            analytics.sentiment_trends[full_name] = self.generate_sentiment_trend(full_name, speaker)
+            self.analytics.sentiment_trends[full_name] = self.generate_sentiment_trend(full_name, speaker)
 
         # Build up a list of speaker labels from the config; note that if we have more speakers
         # than configured then we still return something (clear first, as we're appending)
-        analytics.speaker_labels = []
+        self.analytics.speaker_labels = []
         if self.api_mode == cf.API_STANDARD:
             # Standard Transcribe - look them up in the order in the config
             for speaker in range(self.maxSpeakerIndex + 1):
-                next_label = {}
-                next_label["Speaker"] = self.pca_results.get_speaker_prefix(True) + str(speaker)
+                next_label = {"Speaker": self.pca_results.get_speaker_prefix(True) + str(speaker)}
                 try:
                     next_label["DisplayText"] = cf.appConfig[cf.CONF_SPEAKER_NAMES][speaker]
                 except:
                     next_label["DisplayText"] = self.pca_results.get_speaker_prefix(False) + str(speaker)
-                analytics.speaker_labels.append(next_label)
+                self.analytics.speaker_labels.append(next_label)
         elif self.api_mode == cf.API_ANALYTICS:
             # Analytics is more prescriptive - they're defined in the call results
             for speaker in self.analytics_channel_map:
-                next_label = {}
-                next_label["Speaker"] = self.pca_results.get_speaker_prefix(True) + str(
-                    self.analytics_channel_map[speaker])
-                next_label["DisplayText"] = speaker.title()
-                analytics.speaker_labels.append(next_label)
+                next_label = {"Speaker": self.pca_results.get_speaker_prefix(True) + str(
+                    self.analytics_channel_map[speaker]), "DisplayText": speaker.title()}
+                self.analytics.speaker_labels.append(next_label)
 
         # Analytics mode additional metadata
         if self.api_mode == cf.API_ANALYTICS:
             # Speaker and non-talk time
-            analytics.speaker_time = self.extract_analytics_speaker_time(self.asr_output["ConversationCharacteristics"])
-            analytics.categories_detected = analytics.extract_analytics_categories(self.asr_output["Categories"], self.speechSegmentList)
-            analytics.combined_graphic_url = self.create_combined_tca_graphic()
+            self.analytics.speaker_time = self.extract_analytics_speaker_time(self.asr_output["ConversationCharacteristics"])
+            self.analytics.categories_detected = self.analytics.extract_analytics_categories(self.asr_output["Categories"], self.speechSegmentList)
+            self.analytics.combined_graphic_url = self.create_combined_tca_graphic()
         # For non-analytics mode, we can simulate some analytics data
         elif self.api_mode == cf.API_STANDARD:
             # Calculate the speaker time from the speech segments, once per speaker (can't do silent time like this)
             speaker_time = {}
-            for next_speaker in analytics.speaker_labels:
+            for next_speaker in self.analytics.speaker_labels:
                 next_speaker_label = next_speaker["Speaker"]
                 next_speaker_time = sum(
                     (segment.segmentEndTime - segment.segmentStartTime) for segment in self.speechSegmentList if
                     segment.segmentSpeaker == next_speaker_label)
                 speaker_time[next_speaker_label] = {"TotalTimeSecs": float(next_speaker_time)}
-            analytics.speaker_time = speaker_time
+            self.analytics.speaker_time = speaker_time
 
         # Detected custom entity summaries next (clear first, as we're appending)
-        analytics.custom_entities = []
+        self.analytics.custom_entities = []
         for entity in self.headerEntityDict:
-            nextEntity = {}
-            nextEntity["Name"] = entity
-            nextEntity["Instances"] = len(self.headerEntityDict[entity])
-            nextEntity["Values"] = self.headerEntityDict[entity]
-            analytics.custom_entities.append(nextEntity)
+            nextEntity = {"Name": entity,
+                          "Instances": len(self.headerEntityDict[entity]),
+                          "Values": self.headerEntityDict[entity]}
+            self.analytics.custom_entities.append(nextEntity)
 
         # Add on any file-based entity used
         if self.simpleEntityMatchingUsed:
-            analytics.entity_recognizer = cf.appConfig[cf.CONF_ENTITY_FILE]
+            self.analytics.entity_recognizer = cf.appConfig[cf.CONF_ENTITY_FILE]
         elif self.customEntityEndpointName != "":
-            analytics.entity_recognizer = self.customEntityEndpointName
+            self.analytics.entity_recognizer = self.customEntityEndpointName
 
-        # ------------------------
-        # Transcribe Job Info data
-        # ------------------------
-        transcribe_info = analytics.get_transcribe_job()
+        # Some transcribe Job Info data may need to be updated
+        transcribe_info = self.analytics.get_transcribe_job()
 
-        # Some fields we pick off the basic job info
-        transcribe_info.api_mode = self.api_mode
-        transcribe_info.completion_time = str(self.transcribeJobInfo["CompletionTime"])
-        transcribe_info.media_format = self.transcribeJobInfo["MediaFormat"]
-        transcribe_info.media_sample_rate = int(self.transcribeJobInfo["MediaSampleRateHertz"])
-        transcribe_info.media_original_uri = self.transcribeJobInfo["Media"]["MediaFileUri"]
+        # Update the job info with our average confidence score
         transcribe_info.cummulative_word_conf = self.cummulativeWordAccuracy / max(float(self.numWordsParsed), 1.0)
 
         # Did we create an MP3 output file?  If so then use it for playback rather than the original
@@ -289,22 +272,6 @@ class TranscribeParser:
         else:
             transcribe_info.media_playback_uri = transcribe_info.media_original_uri
 
-        # Vocabulary name is optional
-        if "VocabularyName" in self.transcribeJobInfo["Settings"]:
-            transcribe_info.custom_vocab_name = self.transcribeJobInfo["Settings"]["VocabularyName"]
-
-        # Vocabulary filter is optional
-        if "VocabularyFilterName" in self.transcribeJobInfo["Settings"]:
-            transcribe_info.vocab_filter_name = self.transcribeJobInfo["Settings"]["VocabularyFilterName"]
-            transcribe_info.vocab_filter_method = self.transcribeJobInfo["Settings"]["VocabularyFilterMethod"]
-
-        # Some fields are different in the job-status depending upon which API we were using
-        if self.api_mode == cf.API_ANALYTICS:
-            transcribe_info.transcribe_job_name = self.transcribeJobInfo["CallAnalyticsJobName"]
-            transcribe_info.channel_identification = 1
-        else:
-            transcribe_info.transcribe_job_name = self.transcribeJobInfo["TranscriptionJobName"]
-            transcribe_info.channel_identification = int(self.transcribeJobInfo["Settings"]["ChannelIdentification"])
 
     def create_combined_tca_graphic(self):
         """
@@ -419,7 +386,7 @@ class TranscribeParser:
                                              final_second, max_decibel_headroom, "Customer", caller_channel, True, True)
 
         # Generate and store the chart locally
-        base_filename = f"{self.jsonOutputFilename.split('.json')[0]}.png"
+        base_filename = f"{self.analytics.transcribe_job.transcribe_job_name}.png"
         chart_filename = f"{TMP_DIR}/{base_filename}"
         fig.savefig(chart_filename, facecolor="aliceblue")
 
@@ -559,17 +526,16 @@ class TranscribeParser:
                 # Now do the same with the SpeechSegment, but append the full details
                 speech_segment.segmentCustomEntities.append(entity_line)
 
-    def set_comprehend_language_code(self, transcribeLangCode):
-        '''
+    def set_comprehend_language_code(self):
+        """
         Based upon the language defined by the input stream set the best-match language code for Comprehend to use
         for this conversation.  It is "best-match" as Comprehend can model in EN, but has no differentiation between
         EN-US and EN-GB.  If we cannot determine a language to use then we cannot use Comprehend standard models
-        '''
-        self.analytics.conversationLanguageCode = transcribeLangCode
+        """
 
         try:
             for checkLangCode in cf.appConfig[cf.CONF_COMP_LANGS]:
-                if transcribeLangCode.startswith(checkLangCode):
+                if self.analytics.conversationLanguageCode.startswith(checkLangCode):
                     self.comprehendLanguageCode = checkLangCode
                     break
         except:
@@ -763,8 +729,7 @@ class TranscribeParser:
         newLabel = "spk_" + str(speaker)
         return newLabel
 
-
-    def create_turn_by_turn_segments(self, transcribe_job_filename):
+    def create_turn_by_turn_segments(self, sf_event):
         """
         Creates a list of conversational turns, splitting up by speaker or if there's a noticeable pause in
         conversation.  Notes, this works differently for speaker-separated and channel-separated files. For speaker-
@@ -773,22 +738,20 @@ class TranscribeParser:
         channels, then merge any together to ensure we keep to the 3-second pause; this way means that channel- files
         are able to show interleaved speech where speakers are talking over one another.  Once all of this is done
         we inject sentiment into each segment.
+
+        :param sf_event: Event data, as previous steps may send data of use
         """
         speechSegmentList = []
 
-        # Load in the JSON file for processing
-        json_filepath = Path(transcribe_job_filename)
-        self.asr_output = json.load(open(json_filepath.absolute(), "r", encoding="utf-8"))
-        is_analytics_mode = (self.api_mode == cf.API_ANALYTICS)
-
         # Decide on our operational mode and set the overall job language
+        is_analytics_mode = (self.api_mode == cf.API_ANALYTICS)
         if is_analytics_mode:
             # We ignore speaker/channel mode on Analytics
             isChannelMode = False
             isSpeakerMode = False
         else:
             # Channel/Speaker-mode only relevant if not using analytics
-            isChannelMode = self.transcribeJobInfo["Settings"]["ChannelIdentification"]
+            isChannelMode = self.analytics.transcribe_job.channel_identification
             isSpeakerMode = not isChannelMode
 
         lastSpeaker = ""
@@ -943,7 +906,7 @@ class TranscribeParser:
 
             # Create our speaker mapping - we need consistent output like spk_0 | spk_1
             # across all Transcribe API variants to help the UI render it all the same
-            for channel_def in self.transcribeJobInfo["ChannelDefinitions"]:
+            for channel_def in sf_event["channelDefinitions"]:
                 self.analytics_channel_map[channel_def["ParticipantRole"]] = channel_def["ChannelId"]
 
             # Lookup shortcuts
@@ -952,7 +915,7 @@ class TranscribeParser:
             # Each turn has already been processed by Transcribe, so the outputs are in order
             for turn in self.asr_output["Transcript"]:
 
-                 # Get our next speaker name
+                # Get our next speaker name
                 nextSpeaker = self.generate_speaker_label(analytics_ts_speaker=turn["ParticipantRole"])
 
                 # Setup the next speaker block
@@ -1270,7 +1233,7 @@ class TranscribeParser:
         bucket = s3Object.netloc
 
         # 8Khz WAV audio gets converted
-        if (self.transcribeJobInfo["MediaFormat"] == "wav") and (self.transcribeJobInfo["MediaSampleRateHertz"] == 8000):
+        if (self.transcribe_job_info.media_format == "wav") and (self.transcribe_job_info.media_sample_rate == 8000):
             # First, we need to download the original audio file
             fileObject = s3Object.path.lstrip('/')
             inputFilename = TMP_DIR + '/' + fileObject.split('/')[-1]
@@ -1297,59 +1260,19 @@ class TranscribeParser:
                 pcacommon.remove_temp_file(inputFilename)
                 pcacommon.remove_temp_file(outputFilename)
 
-    def load_transcribe_job_info(self, sf_event):
-        """
-        Loads in the job status for the job named in input event.  The event will inform the method which of the
-        Transcribe APIs should be called (e.g. standard or call analytics).
-
-        :param sf_event: Event info passed down from Step Functions
-        :return: The job's current completion status
-        """
-        transcribe_client = boto3.client("transcribe")
-        job_name = sf_event["jobName"]
-        self.api_mode = sf_event["apiMode"]
-
-        if self.api_mode == cf.API_STANDARD:
-            # Standard Transcribe job
-            self.transcribeJobInfo = transcribe_client.get_transcription_job(TranscriptionJobName=job_name)["TranscriptionJob"]
-            job_status = self.transcribeJobInfo["TranscriptionJobStatus"]
-            if "ContentRedaction" in self.transcribeJobInfo:
-                self.transcript_uri = self.transcribeJobInfo["Transcript"]["RedactedTranscriptFileUri"]
-            else:
-                self.transcript_uri = self.transcribeJobInfo["Transcript"]["TranscriptFileUri"]
-        elif self.api_mode == cf.API_ANALYTICS:
-            # Call Analytics Transcribe job
-            self.transcribeJobInfo = transcribe_client.get_call_analytics_job(CallAnalyticsJobName=job_name)["CallAnalyticsJob"]
-            job_status = self.transcribeJobInfo["CallAnalyticsJobStatus"]
-            if "RedactedTranscriptFileUri" in self.transcribeJobInfo["Transcript"]:
-                self.transcript_uri = self.transcribeJobInfo["Transcript"]["RedactedTranscriptFileUri"]
-            else:
-                self.transcript_uri = self.transcribeJobInfo["Transcript"]["TranscriptFileUri"]
-        else:
-            # This should not happen, but will trigger an exception later
-            job_status = "UNKNOWN"
-
-        return job_status
-
     def parse_transcribe_file(self, sf_event):
         """
         Parses the output from the specified Transcribe job
         """
-        # Load in the Amazon Transcribe job header information, ensuring that the job has completed
-        transcribe = boto3.client("transcribe")
-        job_name = sf_event["jobName"]
-        try:
-            job_status = self.load_transcribe_job_info(sf_event)
-            assert job_status == "COMPLETED", f"Transcription job '{job_name}' has not yet completed."
-        except transcribe.exceptions.BadRequestException:
-            assert False, f"Unable to load information for Transcribe job named '{job_name}'."
+
+        # First, load in what interim results we have so far
+        self.pca_results.read_results_from_s3(cf.appConfig[cf.CONF_S3BUCKET_OUTPUT], sf_event["interimResultsFile"])
+        self.api_mode = self.pca_results.analytics.transcribe_job.api_mode
 
         # Create an MP3 playback file if we have to, using the redacted audio file if needed
-        if ("RedactedMediaFileUri" in self.transcribeJobInfo["Media"]) and cf.isAudioRedactionEnabled():
-            # Copy the redacted audio into the playback folder
-            # TODO - Once the UI Lambda that plays the audio is changed to NOT assume that the redacted
-            # TODO - audio is in the input bucket we can just set the playback URI to the audio location
-            redacted_url = "s3://" + "/".join(self.transcribeJobInfo["Media"]["RedactedMediaFileUri"].split("/")[3:])
+        if "redactedMediaFileUri" in sf_event:
+            # Copy the redacted audio into the playback folder if it exists
+            redacted_url = "s3://" + "/".join(sf_event["redactedMediaFileUri"].split("/")[3:])
             s3_object = urlparse(redacted_url)
             s3_client = boto3.resource("s3")
             source = {"Bucket": s3_object.netloc, "Key": s3_object.path[1:]}
@@ -1357,26 +1280,25 @@ class TranscribeParser:
             s3_client.meta.client.copy(source, cf.appConfig[cf.CONF_S3BUCKET_INPUT], dest_key)
             self.audioPlaybackUri = "s3://" + cf.appConfig[cf.CONF_S3BUCKET_INPUT] + "/" + dest_key
         else:
-            # Just sort out the input file
-            self.create_playback_mp3_audio(self.transcribeJobInfo["Media"]["MediaFileUri"])
+            # TODO We need to put ALL playback audio in the playback folder, and assume that the input
+            # TODO folder will be archived away (or just deleted) far sooner than the playback folder
+            # Ensure we have an audio file in the playback folder
+            self.create_playback_mp3_audio(self.analytics.transcribe_job.media_playback_uri)
 
         # Pick out the config parameters that we need
         outputS3Bucket = cf.appConfig[cf.CONF_S3BUCKET_OUTPUT]
 
-        # Parse Call GUID and Agent Name/ID from filename if possible
+        # Parse various fields from the Transcribe job name if possible
+        job_name = self.analytics.transcribe_job.transcribe_job_name
         self.set_guid(job_name)
         self.set_agent(job_name)
         self.set_cust(job_name)
-
-        # Work out the conversation time and set the language code
         self.calculate_transcribe_conversation_time(job_name)
-        self.set_comprehend_language_code(self.transcribeJobInfo["LanguageCode"])
 
-        # Download the job JSON results file to a local temp file - different Transcribe modes put
-        # the files in different folder structures, so just strip everything past the bucket name
-        self.jsonOutputFilename = self.transcript_uri.split("/")[-1]
-        json_filepath = TMP_DIR + '/' + self.jsonOutputFilename
-        transcriptResultsKey = "/".join(self.transcript_uri.split("/")[4:])
+        # Download the job JSON results file to a local temp file - different Transcribe modes put the files in
+        # different folder structures, so strip everything past the bucket name to be the location of the tmp file
+        json_filepath = TMP_DIR + '/' + sf_event["transcriptUri"].split("/")[-1]
+        transcriptResultsKey = "/".join(sf_event["transcriptUri"].split("/")[4:])
 
         # Now download - this has been known to get a "404 HeadObject Not Found",
         # which makes no sense, so if that happens then re-try in a sec.  Only once.
@@ -1387,32 +1309,38 @@ class TranscribeParser:
             time.sleep(3)
             s3Client.download_file(outputS3Bucket, transcriptResultsKey, json_filepath)
 
-        # Before we process, let's load up any required simply entity map
+        # Load in the JSON file for processing, and set our language codes for the file and Comprehend
+        self.asr_output = json.load(open(Path(json_filepath).absolute(), "r", encoding="utf-8"))
+
+        # Before we process, let's load up any required simply entity map, which needs the base language code
+        self.set_comprehend_language_code()
         self.load_simple_entity_string_map()
 
         # Now create turn-by-turn diarisation, with associated sentiments and entities
-        self.speechSegmentList = self.create_turn_by_turn_segments(json_filepath)
+        self.speechSegmentList = self.create_turn_by_turn_segments(sf_event)
 
         # Update our results data structures, generate JSON results and save them to S3
         self.push_turn_by_turn_results()
 
-        # Write out the JSON data to our S3 location
-        interim_results_file_key = TEMP_OUTPUT_KEY + '/' + self.jsonOutputFilename
-        json_output = self.pca_results.write_results_to_s3(outputS3Bucket, interim_results_file_key)
+        # Write out the JSON data back to our interim S3 location
+        json_output = self.pca_results.write_results_to_s3(bucket=outputS3Bucket, object_key=sf_event["interimResultsFile"])
 
-        # Index transcript in Kendra, if transcript search is enabled
+        # Index transcript in Kendra, if transcript search is enable
         kendraIndexId = cf.appConfig[cf.CONF_KENDRA_INDEX_ID]
         if kendraIndexId != "None":
-            analysisUri = f"{cf.appConfig[cf.CONF_WEB_URI]}dashboard/parsedFiles/{self.jsonOutputFilename}"
+            analysisUri = f"{cf.appConfig[cf.CONF_WEB_URI]}dashboard/parsedFiles/{json_filepath.split('/')[-1]}"
             transcript_with_markers = prepare_transcript(json_filepath)
+            # TODO Check we can get this from "self", then we can remove json_output from the write_to_s3 call above
             conversationAnalytics = json_output["ConversationAnalytics"]
             put_kendra_document(kendraIndexId, analysisUri, conversationAnalytics, transcript_with_markers)
 
+        # Finally, remove any Step Functions data that we don't need to pass on (they won't all exist)
+        sf_event.pop("transcriptUri", None)
+        sf_event.pop("channelDefinitions", None)
+        sf_event.pop("redactedMediaFileUri", None)
+
         # delete the local file
         pcacommon.remove_temp_file(json_filepath)
-
-        # Return our interim results file key for re-use later
-        return interim_results_file_key
 
 
 def lambda_handler(event, context):
@@ -1424,10 +1352,9 @@ def lambda_handler(event, context):
     transcribeParser = TranscribeParser(cf.appConfig[cf.CONF_MINPOSITIVE],
                                         cf.appConfig[cf.CONF_MINNEGATIVE],
                                         cf.appConfig[cf.CONF_ENTITYENDPOINT])
-    output_filename = transcribeParser.parse_transcribe_file(sf_data)
+    transcribeParser.parse_transcribe_file(sf_data)
 
-    # Add tag the location of the output file to the SF data, along with the requested telephony CTR type
-    sf_data["interimResultsFile"] = output_filename
+    # Add the requested telephony CTR type
     sf_data["telephony"] = cf.appConfig[cf.CONF_TELEPHONY_CTR]
     return sf_data
 
@@ -1435,16 +1362,38 @@ def lambda_handler(event, context):
 # Main entrypoint for testing
 if __name__ == "__main__":
     # Test event
-    event = {
+    test_event_analytics = {
         "bucket": "ak-cci-input",
-        "langCode": "en-US",
-        "transcribeStatus": "COMPLETED",
+        "key": "originalAudio/Card2_GUID_102_AGENT_AndrewK_DT_2022-03-22T12-23-49.wav",
+        "inputType": "audio",
+        "jobName": "Card2_GUID_102_AGENT_AndrewK_DT_2022-03-22T12-23-49.wav",
         "apiMode": "analytics",
-        # "key": "originalAudio/006c7659-258e-4adc-a036-df717505e25a.wav",
-        # "jobName": "006c7659-258e-4adc-a036-df717505e25a.wav"
-        "key": "originalAudio/fd4bd0f6-52c2-4fab-97de-8f7518474403.wav",
-        "jobName": "fd4bd0f6-52c2-4fab-97de-8f7518474403.wav"
-        # "key": "originalAudio/fef9f532-08e0-436c-b0cc-7df991521e96.wav",
-        # "jobName": "fef9f532-08e0-436c-b0cc-7df991521e96.wav"
+        "transcribeStatus": "COMPLETED",
+        "redactedMediaFileUri": "https://s3.us-east-1.amazonaws.com/ak-cci-output/transcribeResults/redacted-analytics/Card2_GUID_102_AGENT_AndrewK_DT_2022-03-22T12-23-49.wav.wav",
+        "transcriptUri": "https://s3.us-east-1.amazonaws.com/ak-cci-output/transcribeResults/redacted-analytics/Card2_GUID_102_AGENT_AndrewK_DT_2022-03-22T12-23-49.wav.json",
+        "channelDefinitions": [{'ChannelId': 1, 'ParticipantRole': 'AGENT'}, {'ChannelId': 0, 'ParticipantRole': 'CUSTOMER'}],
+        "interimResultsFile": "interimResults/Card2_GUID_102_AGENT_AndrewK_DT_2022-03-22T12-23-49.wav.json"
     }
-    lambda_handler(event, "")
+    test_event_stereo = {
+        "bucket": "ak-cci-input",
+        "key": "originalAudio/Auto3_GUID_003_AGENT_BobS_DT_2022-03-21T17-51-51.wav",
+        "inputType": "audio",
+        "jobName": "Auto3_GUID_003_AGENT_BobS_DT_2022-03-21T17-51-51.wav",
+        "apiMode": "standard",
+        "transcribeStatus": "COMPLETED",
+        "transcriptUri": "https://s3.us-east-1.amazonaws.com/ak-cci-output/transcribeResults/redacted-Auto3_GUID_003_AGENT_BobS_DT_2022-03-21T17-51-51.wav.json",
+        "interimResultsFile": "interimResults/redacted-Auto3_GUID_003_AGENT_BobS_DT_2022-03-21T17-51-51.wav.json"
+    }
+    test_event_mono = {
+        "bucket": "ak-cci-input",
+        "key": "originalAudio/Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav",
+        "inputType": "audio",
+        "jobName": "Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav",
+        "apiMode": "standard",
+        "transcribeStatus": "COMPLETED",
+        "transcriptUri": "https://s3.us-east-1.amazonaws.com/ak-cci-output/transcribeResults/redacted-Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav.json",
+        "interimResultsFile": "interimResults/redacted-Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav.json"
+    }
+    lambda_handler(test_event_analytics, "")
+    lambda_handler(test_event_stereo, "")
+    lambda_handler(test_event_mono, "")

--- a/pca-server/src/pca/pcacommon.py
+++ b/pca-server/src/pca/pcacommon.py
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 import os
 import time
+import subprocess
 import pcaconfiguration as cf
 
 
@@ -36,6 +37,27 @@ def remove_temp_file(file_path):
     # Delete the file if it exists
     if os.path.exists(file_path):
         os.remove(file_path)
+
+
+def ffprobe_get_stream_entries(select_data, filename):
+    """
+    Calls FFPROBE to look at the streams-based metadata for a given audio file, but you specify which
+    aspect of the stream data to be returned.  To see what's available in the stream run this:
+
+    ffprobe -hide_banner -loglevel panic -show_format -show_streams -of json <filename>
+
+    Note that this could exception for many reason, so the caller should be prepared for failure
+
+    :param select_data: The stream data that you're trying to parse; e.g. stream=sample_rate
+    :param filename: Full path to local file to be probed
+    :return: Data returned from FFPROBE
+    """
+    command = ['ffprobe', '-v', 'error', '-select_streams', 'a', '-of',
+               'default=noprint_wrappers=1:nokey=1', '-show_entries',
+               select_data, filename]
+    prob_result = subprocess.check_output(command, stderr=subprocess.STDOUT).decode()
+
+    return prob_result.strip('\n')
 
 
 def comprehend_single_sentiment(text, lang_code, scalar=1.0, client=None):

--- a/pca-server/src/pca/pcaconfiguration.py
+++ b/pca-server/src/pca/pcaconfiguration.py
@@ -16,10 +16,11 @@ CONF_ENTITYENDPOINT = "EntityRecognizerEndpoint"
 CONF_ENTITY_FILE = "EntityStringMap"
 CONF_ENTITYCONF = "EntityThreshold"
 CONF_ENTITY_TYPES = "EntityTypes"
-CONF_PREFIX_MP3_PLAYBACK = "InputBucketAudioPlayback"
+CONF_PREFIX_AUDIO_PLAYBACK = "InputBucketAudioPlayback"
 CONF_S3BUCKET_INPUT = "InputBucketName"
 CONF_PREFIX_RAW_AUDIO = "InputBucketRawAudio"
 CONF_PREFIX_FAILED_AUDIO = "InputBucketFailedTranscriptions"
+CONF_PREFIX_INPUT_TRANSCRIPTS = "InputBucketOrigTranscripts"
 CONF_MAX_SPEAKERS = "MaxSpeakers"
 CONF_MINNEGATIVE = "MinSentimentNegative"
 CONF_MINPOSITIVE = "MinSentimentPositive"
@@ -107,15 +108,16 @@ def loadConfiguration():
             CONF_ENTITYENDPOINT,
             CONF_ENTITY_FILE,
             CONF_ENTITYCONF,
-            CONF_PREFIX_MP3_PLAYBACK,
+            CONF_PREFIX_AUDIO_PLAYBACK,
             CONF_S3BUCKET_INPUT,
             CONF_PREFIX_RAW_AUDIO,
             CONF_PREFIX_FAILED_AUDIO,
-            CONF_MAX_SPEAKERS,
+            CONF_PREFIX_INPUT_TRANSCRIPTS,
         ]
     )
     fullParamList2 = ssm.get_parameters(
         Names=[
+            CONF_MAX_SPEAKERS,
             CONF_MINNEGATIVE,
             CONF_MINPOSITIVE,
             CONF_S3BUCKET_OUTPUT,
@@ -125,11 +127,11 @@ def loadConfiguration():
             COMP_SFN_NAME,
             CONF_SUPPORT_BUCKET,
             CONF_TRANSCRIBE_LANG,
-            CONF_PREFIX_TRANSCRIBE_RESULTS,
         ]
     )
     fullParamList3 = ssm.get_parameters(
         Names=[
+            CONF_PREFIX_TRANSCRIBE_RESULTS,
             CONF_VOCABNAME,
             CONF_CONVO_LOCATION,
             CONF_ENTITY_TYPES,
@@ -139,11 +141,11 @@ def loadConfiguration():
             CONF_FILENAME_DATETIME_FIELDMAP,
             CONF_FILENAME_GUID_REGEX,
             CONF_FILENAME_AGENT_REGEX,
-            CONF_FILENAME_CUST_REGEX,
         ]
     )
     fullParamList4 = ssm.get_parameters(
         Names=[
+            CONF_FILENAME_CUST_REGEX,
             CONF_KENDRA_INDEX_ID,
             CONF_WEB_URI,
             CONF_TRANSCRIBE_API,

--- a/pca-server/src/pca/pcaconfiguration.py
+++ b/pca-server/src/pca/pcaconfiguration.py
@@ -56,6 +56,7 @@ BULK_MAX_DRIP_RATE = "BulkUploadMaxDripRate"
 # Transcribe API Modes
 API_STANDARD = "standard"
 API_ANALYTICS = "analytics"
+API_STREAM_ANALYTICS = "analytics-streaming"
 
 # Speaker separation modes
 SPEAKER_MODE_SPEAKER = "speaker"
@@ -188,6 +189,7 @@ def loadConfiguration():
     appConfig[CONF_TRANSCRIBE_LANG] = appConfig[CONF_TRANSCRIBE_LANG].split(" | ")
     appConfig[CONF_SPEAKER_NAMES] = appConfig[CONF_SPEAKER_NAMES].split(" | ")
     appConfig[CONF_TELEPHONY_CTR_SUFFIX] = appConfig[CONF_TELEPHONY_CTR_SUFFIX].split(" | ")
+
 
 def isAutoLanguageDetectionSet():
     """

--- a/pca-ssm/cfn/ssm.template
+++ b/pca-ssm/cfn/ssm.template
@@ -23,7 +23,7 @@ Parameters:
 
   ComprehendLanguages:
     Type: String
-    Default: en | es | fr | de | it | pt | ar | hi | ja | ko | zh | zh-TW
+    Default: de | en | es | it | pt | fr | ja | ko | hi | ar | zh | zh-TW
     Description: Languages supported by Comprehend's standard calls, separated by " | "
 
   ContentRedactionLanguages:

--- a/pca-ssm/cfn/ssm.template
+++ b/pca-ssm/cfn/ssm.template
@@ -58,7 +58,7 @@ Parameters:
 
   InputBucketAudioPlayback:
     Type: String
-    Default: mp3
+    Default: playbackAudio
     Description: Folder that holds the audio files to playback in the browser when original audio cannot be used
 
   InputBucketFailedTranscriptions:
@@ -76,6 +76,13 @@ Parameters:
     Type: String
     Default: originalAudio
     Description: Folder that holds the audio files to be ingested into the system
+
+  InputBucketOrigTranscripts:
+    Type: String
+    Default: originalTranscripts
+    Description: >-
+      Folder that holds Transcripts from other applications (e.g. Live Call Analytics) that are to be
+      processed as if PCA had processed that audio
 
   MaxSpeakers:
     Type: String
@@ -361,6 +368,16 @@ Resources:
       Type: String
       Description: Folder that holds the original call audio to be ingested
       Value: !Ref InputBucketRawAudio
+
+  InputBucketOrigTranscriptsParameter:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: InputBucketOrigTranscripts
+      Type: String
+      Description: >
+        Folder that holds Transcripts from other applications (e.g. Live Call Analytics) that are to be
+        processed as if PCA had processed that audio
+      Value: !Ref InputBucketOrigTranscripts
 
   MaxSpeakersParameter:
     Type: "AWS::SSM::Parameter"

--- a/pca-ui/src/www/src/routes/Dashboard/index.js
+++ b/pca-ui/src/www/src/routes/Dashboard/index.js
@@ -53,6 +53,10 @@ function Dashboard({ setAlert }) {
     data?.ConversationAnalytics?.SourceInformation[0]?.TranscribeJobInfo
       ?.TranscribeApiType === "analytics";
 
+  const hasTranscribeStreamingSession =
+    data?.ConversationAnalytics?.SourceInformation[0]?.TranscribeJobInfo
+      ?.StreamingSession;
+
   useDangerAlert(error, setAlert);
 
   const [speakerLabels, setSpeakerLabels] = useState({
@@ -151,8 +155,12 @@ function Dashboard({ setAlert }) {
       label: "Type",
       value: (d) =>
         isTranscribeCallAnalyticsMode
-          ? "Transcribe Call Analytics"
-          : "Transcribe",
+          ? hasTranscribeStreamingSession
+            ? "Transcribe Streaming Call Analytics"
+            : "Transcribe Call Analytics"
+          : hasTranscribeStreamingSession
+            ? "Transcribe Streaming"
+            : "Transcribe"
     },
     {
       label: "Job Id",
@@ -177,7 +185,14 @@ function Dashboard({ setAlert }) {
         d?.ConversationAnalytics?.SourceInformation[0]?.TranscribeJobInfo
           ?.MediaSampleRateHertz,
     },
-
+    {
+      label: "PII Redaction",
+      value: (d) =>
+        d?.ConversationAnalytics?.SourceInformation[0]?.TranscribeJobInfo
+          ?.RedactedTranscript === true
+          ? "Enabled"
+          : "Disabled"
+    },
     {
       label: "Custom Vocabulary",
       value: (d) =>


### PR DESCRIPTION
Updates to allow for the ingestion of transcripts from Transcribe Streaming Call Analytics.  The main turn-by-turn processor has been refactored to just process the transcript, with new functions added to generate header-level Transcribe information for each input type, either audio files or TCA Streaming transcripts.

The full solution was deployed using CloudFormation with no sample files, and the following tests carried out:

**Initial Default Mode** - Analytics

Copy the following audio files into the `originalAudio` folder:

- Card2_GUID_102_AGENT_AndrewK_DT_2022-03-22T12-23-49.wav *(stereo/analytics)*
- Auto0_GUID_000_AGENT_ChrisL_DT_2022-03-19T06-01-22_Mono.wav *(mono)*

**Change mode to "standard"**

Copy the following audio file into the `originalAudio` folder:

- Auto3_GUID_003_AGENT_BobS_DT_2022-03-21T17-51-51.wav *(stereo)*

Copy the following transcript file into the `originalTranscripts` folder

- TCA_GUID_3c7161f7-bebc-4951-9cfb-943af1d3a5f5_CUST_17034816544_AGENT_BabuS_2022-11-22T21-32-52.145Z.json

The first three files should display as normal, and the fourth should register a full entry in PCA based solely on the transcript.  Note, at the time of testing the issues were being incorrectly written into the transcript, so are not being displayed (not a PCA fault), but once that bug is corrected PCA will record and display the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
