### PR TITLE
Feature/mono audio file support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 /sample-data
 .vscode
 /pca-ui/src/witch/witch.zip
+pca-server/src/pca/__pycache__

--- a/pca-main-nokendra.template
+++ b/pca-main-nokendra.template
@@ -100,6 +100,11 @@ Parameters:
       Folder that holds Transcripts from other applications (e.g. Live Call Analytics) that are to be
       processed as if PCA had processed that audio
 
+  InputBucketMonoToStereoAudio:
+    Type: String
+    Default: monoToStereoConvertedAudio
+    Description: Prefix/Folder that holds converted mono to stereo audio files
+
   MaxSpeakers:
     Type: String
     Default: "2"
@@ -154,6 +159,13 @@ Parameters:
     Default: PostCallAnalyticsWorkflow
     Description: Name of Step Functions workflow that orchestrates this process
     
+  
+  MonoToStereoStepFunctionName:
+    Type: String
+    AllowedPattern: "[-_a-zA-Z0-9]*"
+    Default: MonoToStereoWorkflow
+    Description: Name of Step Functions workflow that orchestrates mono to stereo audio file converstion
+
   BulkUploadStepFunctionName:
     Type: String
     AllowedPattern: "[-_a-zA-Z0-9]*"
@@ -361,6 +373,7 @@ Metadata:
                   - InputBucketFailedTranscriptions
                   - InputBucketRawAudio
                   - InputBucketOrigTranscripts
+                  - InputBucketMonoToStereoAudio
                   - InputBucketAudioPlayback
                   - OutputBucketParsedResults
                   - OutputBucketTranscribeResults
@@ -512,6 +525,7 @@ Resources:
           - !Ref InputBucketName        
         InputBucketRawAudio: !Ref InputBucketRawAudio
         InputBucketOrigTranscripts: !Ref InputBucketOrigTranscripts
+        InputBucketMonoToStereoAudio: !Ref InputBucketMonoToStereoAudio
         MaxSpeakers: !Ref MaxSpeakers
         MinSentimentNegative: !Ref MinSentimentNegative
         MinSentimentPositive: !Ref MinSentimentPositive
@@ -525,6 +539,7 @@ Resources:
         SpeakerNames: !Ref SpeakerNames
         SpeakerSeparationType: !Ref SpeakerSeparationType
         StepFunctionName: !Ref StepFunctionName
+        MonoToStereoStepFunctionName: !Ref MonoToStereoStepFunctionName
         BulkUploadStepFunctionName: !Ref BulkUploadStepFunctionName
         SupportFilesBucketName: 
           !If

--- a/pca-main.template
+++ b/pca-main.template
@@ -100,6 +100,11 @@ Parameters:
       Folder that holds Transcripts from other applications (e.g. Live Call Analytics) that are to be
       processed as if PCA had processed that audio
 
+  InputBucketMonoToStereoAudio:
+    Type: String
+    Default: monoToStereoConvertedAudio
+    Description: Prefix/Folder that holds converted mono to stereo audio files
+
   MaxSpeakers:
     Type: String
     Default: "2"
@@ -154,6 +159,13 @@ Parameters:
     Default: PostCallAnalyticsWorkflow
     Description: Name of Step Functions workflow that orchestrates this process
     
+  
+  MonoToStereoStepFunctionName:
+    Type: String
+    AllowedPattern: "[-_a-zA-Z0-9]*"
+    Default: MonoToStereoWorkflow
+    Description: Name of Step Functions workflow that orchestrates mono to stereo audio file converstion
+
   BulkUploadStepFunctionName:
     Type: String
     AllowedPattern: "[-_a-zA-Z0-9]*"
@@ -363,6 +375,7 @@ Metadata:
                   - InputBucketFailedTranscriptions
                   - InputBucketRawAudio
                   - InputBucketOrigTranscripts
+                  - InputBucketMonoToStereoAudio
                   - InputBucketAudioPlayback
                   - OutputBucketParsedResults
                   - OutputBucketTranscribeResults
@@ -644,6 +657,7 @@ Resources:
           - !Ref InputBucketName        
         InputBucketRawAudio: !Ref InputBucketRawAudio
         InputBucketOrigTranscripts: !Ref InputBucketOrigTranscripts
+        InputBucketMonoToStereoAudio: !Ref InputBucketMonoToStereoAudio
         MaxSpeakers: !Ref MaxSpeakers
         MinSentimentNegative: !Ref MinSentimentNegative
         MinSentimentPositive: !Ref MinSentimentPositive
@@ -657,6 +671,7 @@ Resources:
         SpeakerNames: !Ref SpeakerNames
         SpeakerSeparationType: !Ref SpeakerSeparationType
         StepFunctionName: !Ref StepFunctionName
+        MonoToStereoStepFunctionName: !Ref MonoToStereoStepFunctionName
         BulkUploadStepFunctionName: !Ref BulkUploadStepFunctionName
         SupportFilesBucketName: 
           !If

--- a/pca-server/cfn/lib/mono-to-stereo-SM-defination.json
+++ b/pca-server/cfn/lib/mono-to-stereo-SM-defination.json
@@ -1,0 +1,156 @@
+{
+  "Comment": "A description of my state machine",
+  "StartAt": "Lambda: count_audio_channel",
+  "States": {
+    "Lambda: count_audio_channel": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "Payload.$": "$",
+        "FunctionName": "${countAudioChannelArn}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Choice: mono_or_stereo?"
+    },
+    "Choice: mono_or_stereo?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.channel",
+          "NumericEquals": 1,
+          "Next": "Lambda: start_transcribe_job"
+        }
+      ],
+      "Default": "Lambda: trigger_post_call_analytics_SM"
+    },
+    "Lambda: trigger_post_call_analytics_SM": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "Payload.$": "$",
+        "FunctionName": "${triggerPostCallAnalyticsSMArn}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "End": true
+    },
+    "Lambda: start_transcribe_job": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "Payload.$": "$",
+        "FunctionName": "${startTranscribeJobArn}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Wait"
+    },
+    "Wait": {
+      "Type": "Wait",
+      "Seconds": 10,
+      "Next": "Lambda: transcribe_job_status"
+    },
+    "Lambda: transcribe_job_status": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "Payload.$": "$",
+        "FunctionName": "${checkTranscribeJobStatusArn}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Choice: job_complete?"
+    },
+    "Choice: job_complete?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.transcriptionJobStatus",
+          "StringEquals": "COMPLETED",
+          "Next": "Lambda: convert_mono_to_stereo_audio"
+        },
+        {
+          "Variable": "$.transcriptionJobStatus",
+          "StringEquals": "FAILED",
+          "Next": "Fail"
+        }
+      ],
+      "Default": "Wait"
+    },
+    "Fail": {
+      "Type": "Fail"
+    },
+    "Lambda: convert_mono_to_stereo_audio": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "Payload.$": "$",
+        "FunctionName": "${convertMonoToStereoAudioArn}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Lambda: trigger_post_call_analytics_SM"
+    }
+  }
+}

--- a/pca-server/cfn/lib/mono-to-stereo.yml
+++ b/pca-server/cfn/lib/mono-to-stereo.yml
@@ -1,0 +1,342 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+
+Description: my_stack - Mono-To-Stereo-Conversion - StateMachine
+
+Parameters:
+  FFMPEGZipName:
+    Type: String
+    Default: ffmpeg.zip
+
+  SupportFilesBucketName:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: SupportFilesBucketName
+
+  StepFunctionName:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: StepFunctionName
+
+  MonoToStereoStepFunctionName:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: MonoToStereoStepFunctionName
+    
+  InputBucketName:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: InputBucketName
+
+  OutputBucketName:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: OutputBucketName
+
+Resources:
+  FFMPEGLayer:
+    Type: "AWS::Lambda::LayerVersion"
+    Properties:
+      Content:
+        S3Bucket: !Ref SupportFilesBucketName
+        S3Key: !Ref FFMPEGZipName
+
+  MonoToStereoSMLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties: 
+      LogGroupName: !Sub '/aws/vendedlogs/${MonoToStereoStepFunctionName}'
+      RetentionInDays: 90
+
+## IAM Roles
+  countAudioChannelRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: S3BucketReadWritePolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:ListBucket
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:DeleteObject
+                Resource:
+                  - !Sub arn:aws:s3:::${InputBucketName}
+                  - !Sub arn:aws:s3:::${InputBucketName}/*
+  
+  startTranscribeJobRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/AmazonTranscribeFullAccess
+      Policies:
+        - PolicyName: PassRoleToTranscribe
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource:
+                  - !GetAtt startTranscribeJobDataAccessRole.Arn
+        - PolicyName: S3BucketReadWritePolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:ListBucket
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:DeleteObject
+                Resource:
+                  - !Sub arn:aws:s3:::${InputBucketName}
+                  - !Sub arn:aws:s3:::${InputBucketName}/*
+        - PolicyName: SSMGetParameterPolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter*
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*
+
+  startTranscribeJobDataAccessRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - transcribe.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: S3BucketReadWritePolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:ListBucket
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:DeleteObject
+                Resource:
+                  - !Sub arn:aws:s3:::${InputBucketName}
+                  - !Sub arn:aws:s3:::${InputBucketName}/*
+                  - !Sub arn:aws:s3:::${OutputBucketName}
+                  - !Sub arn:aws:s3:::${OutputBucketName}/*
+
+  checkTranscribeJobStatusRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/AmazonTranscribeFullAccess
+      
+  convertMonoToStereoAudioRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/AmazonTranscribeFullAccess
+      Policies:
+        - PolicyName: S3BucketReadWritePolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:ListBucket
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:DeleteObject
+                Resource:
+                  - !Sub arn:aws:s3:::${InputBucketName}
+                  - !Sub arn:aws:s3:::${InputBucketName}/*
+                  - !Sub arn:aws:s3:::${OutputBucketName}
+                  - !Sub arn:aws:s3:::${OutputBucketName}/*
+        - PolicyName: SSMGetParameterPolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter*
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*
+  
+  triggerPostCallAnalyticsSMRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: StateMachineExecutionPolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - states:StartExecution
+                Resource:
+                  - !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StepFunctionName}
+              - Effect: Allow
+                Action:
+                  - states:ListStateMachines
+                Resource: "*"
+        - PolicyName: SSMGetParameterPolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter*
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*
+
+  monoToStereoStateMachineRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: states.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AllowInvokeFunctions
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource:
+                  - !GetAtt countAudioChannel.Arn
+                  - !GetAtt startTranscribeJob.Arn
+                  - !GetAtt checkTranscribeJobStatus.Arn
+                  - !GetAtt convertMonoToStereoAudio.Arn
+                  - !GetAtt triggerPostCallAnalyticsSM.Arn                  
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Statement:
+            - Effect: Allow
+              Action:
+              - logs:*LogDelivery
+              - logs:ListLogDeliveries
+              - logs:PutResourcePolicy
+              - logs:DescribeResourcePolicies
+              - logs:DescribeLogGroups
+              Resource: "*"
+
+## Lambda 
+  countAudioChannel:
+    Type: "AWS::Serverless::Function"
+    Properties:
+      CodeUri:  ../../src/mono-to-stereo-lambda/count_audio_channel
+      Handler: index.lambda_handler
+      Runtime: python3.9
+      MemorySize: 1024
+      Timeout: 60
+      Layers:
+        - !Ref FFMPEGLayer
+      Role: !GetAtt countAudioChannelRole.Arn
+
+  startTranscribeJob:
+    Type: "AWS::Serverless::Function"
+    Properties:
+      CodeUri:  ../../src/mono-to-stereo-lambda/start_transcribe_job
+      Handler: index.lambda_handler
+      Runtime: python3.9
+      MemorySize: 1024
+      Timeout: 60
+      Environment:
+        Variables:
+          RoleArn: !GetAtt startTranscribeJobDataAccessRole.Arn
+      Role: !GetAtt startTranscribeJobRole.Arn
+
+  checkTranscribeJobStatus:
+    Type: "AWS::Serverless::Function"
+    Properties:
+      CodeUri:  ../../src/mono-to-stereo-lambda/check_transcribe_job_status
+      Handler: index.lambda_handler
+      Runtime: python3.9
+      MemorySize: 1024
+      Timeout: 60
+      Role: !GetAtt checkTranscribeJobStatusRole.Arn
+
+  convertMonoToStereoAudio:
+    Type: "AWS::Serverless::Function"
+    Properties:
+      CodeUri:  ../../src/mono-to-stereo-lambda/convert_mono_to_stereo_audio
+      Handler: index.lambda_handler
+      Runtime: python3.9
+      MemorySize: 1024
+      Timeout: 60
+      Layers:
+        - !Ref FFMPEGLayer
+      Role: !GetAtt convertMonoToStereoAudioRole.Arn
+
+  triggerPostCallAnalyticsSM:
+    Type: "AWS::Serverless::Function"
+    Properties:
+      CodeUri:  ../../src/mono-to-stereo-lambda/trigger_post_call_analytics_SM
+      Handler: index.lambda_handler
+      Runtime: python3.9
+      MemorySize: 1024
+      Timeout: 10
+      Role: !GetAtt triggerPostCallAnalyticsSMRole.Arn
+
+
+## State Machine
+  monoToStereoStateMachine:
+    Type: "AWS::StepFunctions::StateMachine"
+    Properties:
+      StateMachineName: !Ref MonoToStereoStepFunctionName
+      DefinitionS3Location: ./mono-to-stereo-SM-defination.json
+      DefinitionSubstitutions:
+        countAudioChannelArn: !GetAtt countAudioChannel.Arn
+        startTranscribeJobArn: !GetAtt startTranscribeJob.Arn
+        checkTranscribeJobStatusArn: !GetAtt checkTranscribeJobStatus.Arn
+        convertMonoToStereoAudioArn: !GetAtt convertMonoToStereoAudio.Arn
+        triggerPostCallAnalyticsSMArn: !GetAtt triggerPostCallAnalyticsSM.Arn   
+      LoggingConfiguration:
+        Level: ERROR
+        IncludeExecutionData: true
+        Destinations:
+          - CloudWatchLogsLogGroup:
+              LogGroupArn: !GetAtt MonoToStereoSMLogGroup.Arn
+      RoleArn: !GetAtt monoToStereoStateMachineRole.Arn
+
+Outputs:
+  RolesForKMSKey:
+    Value: !Join
+        - ', '
+        - - !Sub '"${countAudioChannelRole.Arn}"'
+          - !Sub '"${startTranscribeJobRole.Arn}"'
+          - !Sub '"${checkTranscribeJobStatusRole.Arn}"'
+          - !Sub '"${convertMonoToStereoAudioRole.Arn}"'
+          - !Sub '"${triggerPostCallAnalyticsSMRole.Arn}"'
+          - !Sub '"${monoToStereoStateMachineRole.Arn}"'

--- a/pca-server/cfn/lib/trigger.template
+++ b/pca-server/cfn/lib/trigger.template
@@ -26,6 +26,10 @@ Parameters:
     Type: AWS::SSM::Parameter::Value<String>
     Default: InputBucketOrigTranscripts
 
+  MonoToStereoStepFunctionName:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: MonoToStereoStepFunctionName
+
   StepFunctionName:
     Type: AWS::SSM::Parameter::Value<String>
     Default: StepFunctionName
@@ -71,8 +75,9 @@ Resources:
         - Sid: StartExecutionPolicy
           Effect: Allow
           Action: states:StartExecution
-          Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StepFunctionName}
-
+          Resource:
+            - !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StepFunctionName}
+            - !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${MonoToStereoStepFunctionName}
     
   FileDropTriggerPermission:
     Type: AWS::Lambda::Permission

--- a/pca-server/cfn/pca-server.template
+++ b/pca-server/cfn/pca-server.template
@@ -47,6 +47,13 @@ Resources:
     Properties:
       TemplateURL: lib/ddb.template
 
+  MONOTOSTEREOPCA:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: lib/mono-to-stereo.yml
+      Parameters:
+        FFMPEGZipName: !GetAtt FFMPEG.Outputs.FFMPEGZipName
+
   PCA:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -77,6 +84,7 @@ Resources:
     DependsOn:
       - PCA
       - Trigger
+      - MONOTOSTEREOPCA
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: lib/copy-samples.template
@@ -93,6 +101,7 @@ Outputs:
       - ', '
       - - !Sub '${Trigger.Outputs.RolesForKMSKey}'
         - !Sub '${PCA.Outputs.RolesForKMSKey}'
+        - !Sub '${MONOTOSTEREOPCA.Outputs.RolesForKMSKey}'
         - !Sub '${BulkImport.Outputs.RolesForKMSKey}'
         - !If [ShouldLoadSampleAudioFiles, !Sub '${CopySamples.Outputs.RolesForKMSKey}', !Ref AWS::NoValue]
 

--- a/pca-server/src/mono-to-stereo-lambda/check_transcribe_job_status/index.py
+++ b/pca-server/src/mono-to-stereo-lambda/check_transcribe_job_status/index.py
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import boto3
+
+def lambda_handler(event, context):
+    
+    bucket = event['bucket']
+    key = event['key']
+    input_type = event['inputType']
+    job_name = event['jobName']
+    
+    transcribe_client = boto3.client("transcribe")
+    transcript_response = transcribe_client.get_transcription_job(TranscriptionJobName=job_name)["TranscriptionJob"]
+    job_status = transcript_response['TranscriptionJobStatus']
+    
+    return {
+        'bucket': bucket,
+        'key': key,
+        'inputType': input_type,
+        'jobName': job_name,
+        'statusCode': 200,
+        'transcriptionJobStatus': job_status
+    }

--- a/pca-server/src/mono-to-stereo-lambda/convert_mono_to_stereo_audio/helper.py
+++ b/pca-server/src/mono-to-stereo-lambda/convert_mono_to_stereo_audio/helper.py
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+def remove_temp_file(file_path):
+    """
+    Checks if the specified file exists and deletes it if it does
+
+    @param file_path: Path to the file to be deleted
+    """
+    # Delete the file if it exists
+    if os.path.exists(file_path):
+        os.remove(file_path)

--- a/pca-server/src/mono-to-stereo-lambda/convert_mono_to_stereo_audio/index.py
+++ b/pca-server/src/mono-to-stereo-lambda/convert_mono_to_stereo_audio/index.py
@@ -1,0 +1,93 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import boto3
+from urllib.parse import urlparse
+import ssm_param_config as cf
+import os
+from helper import *
+
+def lambda_handler(event, context):
+    key = event["key"]
+    input_type = event['inputType']
+    job_name = event["jobName"]
+    
+    s3_client = boto3.client("s3")
+
+    cf.loadConfiguration()
+    
+    transcribe_client = boto3.client("transcribe")
+    transcript_response = transcribe_client.get_transcription_job(TranscriptionJobName=job_name)["TranscriptionJob"]
+
+    
+    ip_file_s3_uri = transcript_response["Media"]["MediaFileUri"]
+    redacted_transcript_uri = transcript_response["Transcript"]["RedactedTranscriptFileUri"]
+    
+    parse_temp = urlparse(ip_file_s3_uri, allow_fragments=False)
+    
+    ip_file_name = ip_file_s3_uri.split("/")[-1]
+    ip_file_tmp_location = '/tmp/'+ip_file_name
+    ip_bucket = parse_temp.netloc
+    ip_file_key = parse_temp.path[1:]
+    
+    op_bucket = urlparse(redacted_transcript_uri).path.split("/")[1]
+    
+    li = urlparse(redacted_transcript_uri).path.split("/")[2:]
+    op_key = "/".join(li)
+    
+    op_file_name = urlparse(redacted_transcript_uri).path.split("/")[-1]
+    op_file_tmp_location = '/tmp/'+op_file_name
+
+    s3_client.download_file(op_bucket, op_key, op_file_tmp_location)
+    s3_client.download_file(ip_bucket, ip_file_key, ip_file_tmp_location)
+    
+    f = open(op_file_tmp_location)
+    transcript = json.load(f)
+    print(transcript)
+    
+    speaker_dict = {}
+    segments = transcript['results']['speaker_labels']['segments']
+    for item in segments:
+        speaker_label = item['speaker_label']
+        s = 'volume=enable=\'between(t,' + item['start_time'] + ',' + item['end_time'] + ')\':volume=0' + ", "
+        speaker_dict[speaker_label] = speaker_dict.get(speaker_label, "") + s
+
+
+    for key,val in speaker_dict.items():
+        clip_time = "\"" + val[:-2] + "\""
+        clip_op_file_name = "{}_{}".format(key, ip_file_name)
+        clip_op_tmp_location = '/tmp/'+clip_op_file_name
+        command_ = "ffmpeg -i {} -af {} {} -y".format(ip_file_tmp_location, clip_time, clip_op_tmp_location)
+        os.system(command_)
+    
+
+    mono_file1 = "spk_0_"+ip_file_name
+    mono_file1_tmp_loc = '/tmp/'+mono_file1
+    mono_file2 = "spk_1_"+ip_file_name
+    mono_file2_tmp_loc = '/tmp/'+mono_file2
+    stereo_file = "stereo_op_"+ip_file_name
+    stereo_file_tmp_loc = '/tmp/'+stereo_file
+    
+    merge_command = 'ffmpeg -i {} -i {} -filter_complex "[0:a][1:a]join=inputs=2:channel_layout=stereo[a]" -map "[a]" {} -y'\
+                    .format(mono_file1_tmp_loc, mono_file2_tmp_loc, stereo_file_tmp_loc)
+    
+    os.system(merge_command)
+    
+    converted_audio_prefix = cf.appConfig[cf.CONF_PREFIX_MONO_STEREO_CONVERTED_AUDIO]
+    stereo_file_key = converted_audio_prefix + "/"+ stereo_file
+    s3_client.upload_file(stereo_file_tmp_loc, ip_bucket, stereo_file_key)
+    
+    message_str = "File has been saved at s3://{}/{}".format(ip_bucket, stereo_file_key)
+
+    remove_temp_file(mono_file1_tmp_loc)
+    remove_temp_file(mono_file2_tmp_loc)
+    remove_temp_file(stereo_file_tmp_loc)
+    
+    return {
+        'statusCode': 200,
+        'body': json.dumps(message_str),
+        'bucket': ip_bucket,
+        'key': stereo_file_key,
+        'inputType': input_type
+    }

--- a/pca-server/src/mono-to-stereo-lambda/convert_mono_to_stereo_audio/ssm_param_config.py
+++ b/pca-server/src/mono-to-stereo-lambda/convert_mono_to_stereo_audio/ssm_param_config.py
@@ -1,0 +1,53 @@
+"""
+This python function is part of the main processing workflow.  It loads in all of the configuration parameters
+from the SSM Parameter Store and makes them available to all other python functions.  It also includes some helper
+functions to check some logical conditions of some of these configuration parameters.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+import boto3
+
+# Parameter Store Field Names used by main workflow
+CONF_PREFIX_MONO_STEREO_CONVERTED_AUDIO = "InputBucketMonoToStereoAudio"
+# Configuration data
+appConfig = {}
+
+def extractParameters(ssmResponse, useTagName):
+    """
+    Picks out the Parameter Store results and appends the values to our
+    overall 'appConfig' variable.
+    """
+
+    # Good parameters first
+    for param in ssmResponse["Parameters"]:
+        name = param["Name"]
+        value = param["Value"]
+        appConfig[name] = value
+
+    # Now the bad/missing
+    for paramName in ssmResponse["InvalidParameters"]:
+        if useTagName:
+            appConfig[paramName] = paramName
+        else:
+            appConfig[paramName] = ""
+
+
+def loadConfiguration():
+    """
+    Loads in the configuration values from Parameter Store.  Bulk loads them in batches of 10,
+    and any that are missing are set to an empty string or to the tag-name.
+    """
+    
+    # Load the the core ones in from Parameter Store in batches of up to 10
+    ssm = boto3.client("ssm")
+    fullParamList4 = ssm.get_parameters(
+        Names=[
+            CONF_PREFIX_MONO_STEREO_CONVERTED_AUDIO,
+        ]
+    )
+    extractParameters(fullParamList4, False)
+
+
+if __name__ == "__main__":
+    loadConfiguration()

--- a/pca-server/src/mono-to-stereo-lambda/count_audio_channel/helper.py
+++ b/pca-server/src/mono-to-stereo-lambda/count_audio_channel/helper.py
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import boto3
+import subprocess
+
+def remove_temp_file(file_path):
+    """
+    Checks if the specified file exists and deletes it if it does
+
+    @param file_path: Path to the file to be deleted
+    """
+    # Delete the file if it exists
+    if os.path.exists(file_path):
+        os.remove(file_path)
+        
+def count_audio_channels(bucket, key):
+    """
+    Examines an audio file using the FFPROBE utility to determine the number of audio channels in the file.  If
+    any errors occurs then it will default to returning "1", implying that it has just a single channel.
+
+    @param bucket: Bucket holding the audio file to be tested
+    @param key: Key for the audio file in the bucket
+    @return: Number of audio channels found in the file
+    """
+
+    # First, we need to download the original audio file
+    ffmpegInputFilename = "/tmp/" + key.split('/')[-1]
+    s3Client = boto3.client('s3')
+    s3Client.download_file(bucket, key, ffmpegInputFilename)
+
+    # Use ffprobe to count the number of channels in the audio file
+    try:
+        command = ['ffprobe', '-i', ffmpegInputFilename, '-show_entries', 'stream=channels', '-select_streams',
+                   'a:0', '-of', 'compact=p=0:nk=1', '-v', '0']
+        probResult = subprocess.check_output(command, stderr=subprocess.STDOUT).decode()
+        channels_found = int(probResult)
+    except Exception as e:
+        print(f'Failed to get number of audio streams from input file: {str(e)}')
+        channels_found = 1
+    finally:
+        # Delete our downloaded audio
+        remove_temp_file(ffmpegInputFilename)
+
+    return channels_found

--- a/pca-server/src/mono-to-stereo-lambda/count_audio_channel/index.py
+++ b/pca-server/src/mono-to-stereo-lambda/count_audio_channel/index.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from helper import *
+
+def lambda_handler(event, context):
+    bucket = event['bucket']
+    key = event['key']
+    input_type = event['inputType']
+    
+    channel = count_audio_channels(bucket, key)
+    
+    return {
+        'bucket': bucket,
+        'key': key,
+        'inputType': input_type,
+        'statusCode': 200,
+        'channel': channel
+    }

--- a/pca-server/src/mono-to-stereo-lambda/start_transcribe_job/helper.py
+++ b/pca-server/src/mono-to-stereo-lambda/start_transcribe_job/helper.py
@@ -1,0 +1,225 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import boto3
+import pcaconfiguration as cf
+import os
+
+def generate_job_name(object_path):
+    """
+    Transcribe job names cannot contain spaces.  This takes in an S3
+    object key, extracts the filename part, replaces spaces with "-"
+    characters and returns that as the job-name to use
+    """
+
+    # Get rid of leading path, and replace [SPACE] with "-", replace "/" with "-", , replace ":" with "-"
+    response = object_path
+    if "/" in object_path:
+        response = response[1 + object_path.find("/"):]
+    response = response.replace("/", "-")
+    response = response.replace(" ", "-")
+    response = response.replace(":", "-")
+    return response
+
+def check_existing_job_status(job_name, transcribe, api_mode):
+    """
+    Checks the status of the named transcription job, either in the Standard Transcribe APIs or
+    the Call Analytics APIs.  This is required before launching a new job, as our job names are
+    based upon the name of the input audio file, but Transcribe jobs need to be uniquely named
+
+    @param job_name: Name of the transcription job to check for
+    @param transcribe: Boto3 client for the Transcribe service
+    @param api_mode: Transcribe API mode being used
+    @return: Status of the transcription job, empty string means the job didn't exist
+    """
+    try:
+        # Extract the standard Transcribe job status from the correct API
+        if api_mode == cf.API_ANALYTICS:
+            job_status = transcribe.get_call_analytics_job(CallAnalyticsJobName=job_name)["CallAnalyticsJob"]["CallAnalyticsJobStatus"]
+        else:
+            job_status = transcribe.get_transcription_job(TranscriptionJobName=job_name)["TranscriptionJob"]["TranscriptionJobStatus"]
+    except Exception as e:
+        # Job didn't already exist - carry on
+        job_status = ""
+
+    return job_status
+
+
+
+def delete_existing_job(job_name, transcribe, api_mode):
+    """
+    Deletes the specified transcription job from either the Standard or Call Analytics APIs
+
+    @param job_name: Name of the transcription job to delete
+    @param transcribe: Boto3 client for the Transcribe service
+    @param api_mode: Transcribe API mode being used
+    """
+    try:
+        if api_mode == cf.API_ANALYTICS:
+            transcribe.delete_call_analytics_job(CallAnalyticsJobName=job_name)
+        else:
+            transcribe.delete_transcription_job(TranscriptionJobName=job_name)
+    except Exception as e:
+        # If the job has already been deleted then we don't need to take any action
+        print(f"Unable to delete previous Transcribe job {job_name}: {e}")
+        
+        
+
+def add_vocabulary_filter(tag_structure, lang_code, transcribe_client):
+    """
+    Checks to see if our defined vocabulary base name has an instance defined within Transcribe
+    for the given language code.  If it does then it is added as a tag to the provided structure
+
+    :param tag_structure: Dictionary to hold the filter field tag
+    :param lang_code: Language that we're searching for a filter for
+    :param transcribe_client: Boto3 client
+    """
+
+    # Ensure we at least have something to log if there's an exception
+    vocab_filter_name = ""
+
+    try:
+        # Look for a vocabulary filter variant defined for this language code
+        vocab_filter_name = cf.appConfig[cf.CONF_FILTER_NAME] + '-' + lang_code.lower()
+        transcribe_client.get_vocabulary_filter(VocabularyFilterName=vocab_filter_name)
+        tag_structure["VocabularyFilterName"] = vocab_filter_name
+    except:
+        # Doesn't exist for this language code - quietly exit
+        print(f"No vocabulary filter defined named {vocab_filter_name}")
+
+
+def add_custom_vocabulary(tag_structure, lang_code, transcribe_client):
+    """
+    Checks to see if our defined vocabulary base name has an instance defined within Transcribe
+    for the given language code.  If it does then it is added as a tag to the provided structure
+
+    :param tag_structure: Dictionary to hold a "VocabularyName" field if ours exist
+    :param lang_code: Language that we're searching for a vocabulary for
+    :param transcribe_client: Boto3 client
+    """
+
+    # Ensure we at least have something to log if there's an exception
+    vocab_name = ""
+
+    try:
+        # Look for a custom vocabulary variant defined for this language code
+        vocab_name = cf.appConfig[cf.CONF_VOCABNAME] + '-' + lang_code.lower()
+        our_vocab = transcribe_client.get_vocabulary(VocabularyName=vocab_name)
+        if our_vocab["VocabularyState"] == "READY":
+            # It exists, but we can only use it if it is ready for use
+            tag_structure["VocabularyName"] = vocab_name
+    except:
+        # Doesn't exist for this language code - quietly exit
+        print(f"No custom vocabulary defined named {vocab_name}")
+
+        
+        
+def submitTranscribeJob(bucket, key):
+    """
+    Submits the supplied audio file to Transcribe, using the suppplied language code.  The method will decide
+    whether to call the standard Transcribe APIs or the Call Analytics APIs
+
+    @param bucket: Bucket holding the audio file to be tested
+    @param key: Key for the audio file in the bucket
+    @return: Name of the transcription job, and the Transcript API mode
+    """
+
+    # Work out our API mode for Transcribe, and get our boto3 client
+    transcribe = boto3.client('transcribe')
+    api_mode = 'STANDARD'
+    channel_ident = False
+    # Generate job-name - delete if it already exists
+    job_name = generate_job_name(key)
+    current_job_status = check_existing_job_status(job_name, transcribe, api_mode)
+    
+    print("current_job_status ", current_job_status)
+    uri = 's3://{}/{}'.format(bucket, key)
+
+    # If there's a job already running then the input file may have been copied - quit
+    if (current_job_status == "IN_PROGRESS") or (current_job_status == "QUEUED"):
+        # Return empty job name
+        print("A Transcription job named \'{}\' is already in progress - cannot continue.".format(job_name))
+        return ""
+    elif current_job_status != "":
+        # But if an old one exists we can delete it
+        delete_existing_job(job_name, transcribe, api_mode)
+
+    # Setup the structures common to both Standard and Call Analytics
+    job_settings = {}
+    media_settings = {
+        'MediaFileUri': uri
+    }
+
+#     Add our vocab filter method, then check on our language requirements
+    job_settings["VocabularyFilterMethod"] = cf.appConfig[cf.CONF_FILTER_MODE]
+    if len(cf.appConfig[cf.CONF_TRANSCRIBE_LANG]) == 1:
+        # Specific language, so dd a CV and Vocab Filter to our job_setting if either exists for this language
+        lang_code = cf.appConfig[cf.CONF_TRANSCRIBE_LANG][0]
+        add_custom_vocabulary(job_settings, lang_code, transcribe)
+        add_vocabulary_filter(job_settings, lang_code, transcribe)
+
+        # Clear all Language ID settings
+        language_id_settings = None
+        language_options = None
+    else:
+        # Language ID is in play - need to build up language-specific structures
+        language_id_settings = {}
+        language_options = []
+        for language in cf.appConfig[cf.CONF_TRANSCRIBE_LANG]:
+            lang_id_options = {}
+            add_custom_vocabulary(lang_id_options, language, transcribe)
+            add_vocabulary_filter(lang_id_options, language, transcribe)
+            language_id_settings[language] = lang_id_options
+            language_options.append(language)
+
+        # Ensure we clear our "single language" flag
+        lang_code = None
+
+    # Get our role ARN from the environment and enable content redaction (if possible,
+    # and if wanted).  Note, if wanted and LangID is active then we enable it, as if the
+    # detected language doesn't support PII redaction then Transcribe will ignore the setting
+    role_arn = os.environ["RoleArn"]
+#     role_arn = "arn:aws:iam::298757604874:role/s3_full_access"
+    if cf.isTranscriptRedactionEnabled() and \
+             ((lang_code in cf.appConfig[cf.CONF_REDACTION_LANGS]) or language_options is not None):
+        content_redaction = {'RedactionType': 'PII', 'RedactionOutput': 'redacted_and_unredacted'}
+    else:
+        content_redaction = None
+        
+    
+    job_settings['ShowSpeakerLabels'] = True
+#     job_settings['ChannelIdentification'] = channel_ident remove
+
+    # Some settings are valid dependent on the mode
+    if not channel_ident:
+        job_settings["MaxSpeakerLabels"] = int(cf.appConfig[cf.CONF_MAX_SPEAKERS])
+#     job_settings['MaxSpeakerLabels'] =2
+
+    # Job execution settings tp allow queueing of standard Transcribe jobs
+    execution_settings = {
+        "AllowDeferredExecution": True,
+        "DataAccessRoleArn": role_arn
+    }
+
+    # Should have a clear run at doing the job now
+    kwargs = {'TranscriptionJobName': job_name,
+            'IdentifyLanguage': lang_code is None,
+            'LanguageIdSettings': language_id_settings,
+            'LanguageCode': lang_code,
+            'LanguageOptions': language_options,
+              'Media': media_settings,
+            'OutputBucketName': cf.appConfig[cf.CONF_S3BUCKET_OUTPUT],
+            'OutputKey': cf.appConfig[cf.CONF_PREFIX_TRANSCRIBE_RESULTS] + '/mono-file-transcription/',
+              'Settings': job_settings,
+              'JobExecutionSettings': execution_settings,
+              'ContentRedaction': content_redaction
+    }
+
+    # Start the Transcribe job, removing any params that are "None"
+    print({k: v for k, v in kwargs.items() if v is not None})
+    response = transcribe.start_transcription_job(
+        **{k: v for k, v in kwargs.items() if v is not None}
+    )
+
+    # Return our job name and api mode, as we need to track them
+    return job_name, api_mode

--- a/pca-server/src/mono-to-stereo-lambda/start_transcribe_job/index.py
+++ b/pca-server/src/mono-to-stereo-lambda/start_transcribe_job/index.py
@@ -1,0 +1,27 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import pcaconfiguration as cf
+from helper import *
+
+def lambda_handler(event, context):
+    bucket = event['bucket']
+    key = event['key']
+    input_type = event['inputType']
+    
+    cf.loadConfiguration()
+    
+    sfData = copy.deepcopy(event)
+    
+    print(sfData)
+    job_name, api_mode = submitTranscribeJob(bucket,key)
+    
+    
+    return {
+        'statusCode': 200,
+        'bucket': bucket,
+        'key': key,
+        'inputType': input_type,
+        "jobName": job_name
+    }

--- a/pca-server/src/mono-to-stereo-lambda/start_transcribe_job/pcaconfiguration.py
+++ b/pca-server/src/mono-to-stereo-lambda/start_transcribe_job/pcaconfiguration.py
@@ -13,15 +13,15 @@ CONF_COMP_LANGS = "ComprehendLanguages"
 CONF_REDACTION_LANGS = "ContentRedactionLanguages"
 CONF_CONVO_LOCATION = "ConversationLocation"
 CONF_ENTITYENDPOINT = "EntityRecognizerEndpoint"
+CONF_CLASSIFIER_ENDPOINT = "AudioClassifierEndpoint"
 CONF_ENTITY_FILE = "EntityStringMap"
 CONF_ENTITYCONF = "EntityThreshold"
 CONF_ENTITY_TYPES = "EntityTypes"
-CONF_PREFIX_AUDIO_PLAYBACK = "InputBucketAudioPlayback"
+CONF_PREFIX_MP3_PLAYBACK = "InputBucketAudioPlayback"
 CONF_S3BUCKET_INPUT = "InputBucketName"
 CONF_PREFIX_RAW_AUDIO = "InputBucketRawAudio"
 CONF_PREFIX_MONO_STEREO_CONVERTED_AUDIO = "InputBucketMonoToStereoAudio"
 CONF_PREFIX_FAILED_AUDIO = "InputBucketFailedTranscriptions"
-CONF_PREFIX_INPUT_TRANSCRIPTS = "InputBucketOrigTranscripts"
 CONF_MAX_SPEAKERS = "MaxSpeakers"
 CONF_MINNEGATIVE = "MinSentimentNegative"
 CONF_MINPOSITIVE = "MinSentimentPositive"
@@ -58,7 +58,6 @@ BULK_MAX_DRIP_RATE = "BulkUploadMaxDripRate"
 # Transcribe API Modes
 API_STANDARD = "standard"
 API_ANALYTICS = "analytics"
-API_STREAM_ANALYTICS = "analytics-streaming"
 
 # Speaker separation modes
 SPEAKER_MODE_SPEAKER = "speaker"
@@ -111,16 +110,15 @@ def loadConfiguration():
             CONF_ENTITYENDPOINT,
             CONF_ENTITY_FILE,
             CONF_ENTITYCONF,
-            CONF_PREFIX_AUDIO_PLAYBACK,
+            CONF_PREFIX_MP3_PLAYBACK,
             CONF_S3BUCKET_INPUT,
             CONF_PREFIX_RAW_AUDIO,
             CONF_PREFIX_FAILED_AUDIO,
-            CONF_PREFIX_INPUT_TRANSCRIPTS,
+            CONF_MAX_SPEAKERS,
         ]
     )
     fullParamList2 = ssm.get_parameters(
         Names=[
-            CONF_MAX_SPEAKERS,
             CONF_MINNEGATIVE,
             CONF_MINPOSITIVE,
             CONF_S3BUCKET_OUTPUT,
@@ -130,11 +128,11 @@ def loadConfiguration():
             COMP_SFN_NAME,
             CONF_SUPPORT_BUCKET,
             CONF_TRANSCRIBE_LANG,
+            CONF_PREFIX_TRANSCRIBE_RESULTS,
         ]
     )
     fullParamList3 = ssm.get_parameters(
         Names=[
-            CONF_PREFIX_TRANSCRIBE_RESULTS,
             CONF_VOCABNAME,
             CONF_CONVO_LOCATION,
             CONF_ENTITY_TYPES,
@@ -144,11 +142,11 @@ def loadConfiguration():
             CONF_FILENAME_DATETIME_FIELDMAP,
             CONF_FILENAME_GUID_REGEX,
             CONF_FILENAME_AGENT_REGEX,
+            CONF_FILENAME_CUST_REGEX,
         ]
     )
     fullParamList4 = ssm.get_parameters(
         Names=[
-            CONF_FILENAME_CUST_REGEX,
             CONF_KENDRA_INDEX_ID,
             CONF_WEB_URI,
             CONF_TRANSCRIBE_API,
@@ -158,6 +156,7 @@ def loadConfiguration():
             CONF_TELEPHONY_CTR_SUFFIX,
             COMP_MONO_TO_STEREO_SFN_NAME,
             CONF_PREFIX_MONO_STEREO_CONVERTED_AUDIO,
+            CONF_CLASSIFIER_ENDPOINT
         ]
     )
 
@@ -193,7 +192,6 @@ def loadConfiguration():
     appConfig[CONF_TRANSCRIBE_LANG] = appConfig[CONF_TRANSCRIBE_LANG].split(" | ")
     appConfig[CONF_SPEAKER_NAMES] = appConfig[CONF_SPEAKER_NAMES].split(" | ")
     appConfig[CONF_TELEPHONY_CTR_SUFFIX] = appConfig[CONF_TELEPHONY_CTR_SUFFIX].split(" | ")
-
 
 def isAutoLanguageDetectionSet():
     """

--- a/pca-server/src/mono-to-stereo-lambda/trigger_post_call_analytics_SM/index.py
+++ b/pca-server/src/mono-to-stereo-lambda/trigger_post_call_analytics_SM/index.py
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import boto3
+import json
+import ssm_param_config as cf
+
+def lambda_handler(event, context):
+    # Load our configuration
+    cf.loadConfiguration()
+
+    bucket = event['bucket']
+    key = event['key']
+    input_type = event['inputType']
+
+    # File looks good - go find our Step Function
+    ourStepFunction = cf.appConfig[cf.COMP_SFN_NAME] ## trigger the Mono-to-Stereo workflow
+    sfnClient = boto3.client('stepfunctions')
+    sfnMachinesResult = sfnClient.list_state_machines(maxResults=1000)
+    sfnArnList = list(filter(lambda x: x["stateMachineArn"].endswith(ourStepFunction), sfnMachinesResult["stateMachines"]))
+    if sfnArnList == []:
+        raise Exception(
+            'Cannot find configured Step Function \'{}\' in the AWS account in this region - cannot begin workflow.'.format(ourStepFunction))
+    sfnArn = sfnArnList[0]['stateMachineArn']
+
+    # Trigger a new Step Function execution                 
+    parameters = '{\n  \"bucket\": \"' + bucket + '\",\n' + \
+                 '  \"key\": \"' + key + '\",\n' + \
+                 '  \"inputType\": \"' + input_type + '\"\n' + \
+                 '}'
+                 
+    sfnClient.start_execution(stateMachineArn = sfnArn, input = parameters)
+    final_message = f"Post-call analytics workflow for file {key} successfully started."
+
+    # Return our final message
+    return {
+        'bucket': bucket,
+        'key': key,
+        'inputType': input_type,
+        'statusCode': 200,
+        'body': json.dumps(final_message)
+    }

--- a/pca-server/src/mono-to-stereo-lambda/trigger_post_call_analytics_SM/ssm_param_config.py
+++ b/pca-server/src/mono-to-stereo-lambda/trigger_post_call_analytics_SM/ssm_param_config.py
@@ -1,0 +1,59 @@
+"""
+This python function is part of the main processing workflow.  It loads in all of the configuration parameters
+from the SSM Parameter Store and makes them available to all other python functions.  It also includes some helper
+functions to check some logical conditions of some of these configuration parameters.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+import boto3
+
+# Parameter Store Field Names used by main workflow
+
+COMP_SFN_NAME = "StepFunctionName"
+# Configuration data
+appConfig = {}
+
+
+def extractParameters(ssmResponse, useTagName):
+    """
+    Picks out the Parameter Store results and appends the values to our
+    overall 'appConfig' variable.
+    """
+
+    # Good parameters first
+    for param in ssmResponse["Parameters"]:
+        name = param["Name"]
+        value = param["Value"]
+        appConfig[name] = value
+
+    # Now the bad/missing
+    for paramName in ssmResponse["InvalidParameters"]:
+        if useTagName:
+            appConfig[paramName] = paramName
+        else:
+            appConfig[paramName] = ""
+
+
+def loadConfiguration():
+    """
+    Loads in the configuration values from Parameter Store.  Bulk loads them in batches of 10,
+    and any that are missing are set to an empty string or to the tag-name.
+    """
+
+    # Load the the core ones in from Parameter Store in batches of up to 10
+    ssm = boto3.client("ssm")
+    
+    fullParamList2 = ssm.get_parameters(
+        Names=[
+            COMP_SFN_NAME,
+        ]
+    )
+    
+    # Extract our parameters into our config
+   
+    extractParameters(fullParamList2, False)
+    
+
+if __name__ == "__main__":
+    loadConfiguration()

--- a/pca-server/src/pca/pca-aws-file-drop-trigger.py
+++ b/pca-server/src/pca/pca-aws-file-drop-trigger.py
@@ -146,7 +146,11 @@ def invoke_step_function(bucket, key, file_type):
     :param key: Key of for the input trigger file
     :param file_type: The type of file, either "audio" or "transcript"
     """
-    ourStepFunction = cf.appConfig[cf.COMP_SFN_NAME]
+    if file_type=="audio":
+        ourStepFunction = cf.appConfig[cf.COMP_MONO_TO_STEREO_SFN_NAME]
+    elif file_type=="transcript":
+        ourStepFunction = cf.appConfig[cf.COMP_SFN_NAME]
+    
     sfnClient = boto3.client('stepfunctions')
     sfnMachinesResult = sfnClient.list_state_machines(maxResults=1000)
 

--- a/pca-server/src/pca/pca-transcribe-eventbridge.py
+++ b/pca-server/src/pca/pca-transcribe-eventbridge.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
         'id': '0029c6b1-7c8e-1f61-fed5-7ef256b3660b',
         'detail-type': 'Transcribe Job State Change',
         'source': 'aws.transcribe',
-        'account': '710514874879',
+        'account': 'ACCOUNT_ID',
         'time': '2020-08-05T13:32:03Z',
         'region': 'us-east-1',
         'resources': [],

--- a/pca-ssm/cfn/ssm.template
+++ b/pca-ssm/cfn/ssm.template
@@ -84,6 +84,11 @@ Parameters:
       Folder that holds Transcripts from other applications (e.g. Live Call Analytics) that are to be
       processed as if PCA had processed that audio
 
+  InputBucketMonoToStereoAudio:
+    Type: String
+    Default: monoToStereoConvertedAudio
+    Description: Prefix/Folder that holds converted mono to stereo audio files
+
   MaxSpeakers:
     Type: String
     Default: "2"
@@ -131,6 +136,11 @@ Parameters:
     Type: String
     Default: PostCallAnalyticsWorkflow
     Description: Name of Step Functions workflow that orchestrates this process
+  
+  MonoToStereoStepFunctionName:
+    Type: String
+    Default: MonoToStereoWorkflow
+    Description: Name of Step Functions workflow that orchestrates mono to stereo audio file converstion
 
   BulkUploadStepFunctionName:
     Type: String
@@ -379,6 +389,14 @@ Resources:
         processed as if PCA had processed that audio
       Value: !Ref InputBucketOrigTranscripts
 
+  InputBucketMonoToStereoAudioParameter:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: InputBucketMonoToStereoAudio
+      Type: String
+      Description: Folder that holds the original call audio to be ingested
+      Value: !Ref InputBucketMonoToStereoAudio
+
   MaxSpeakersParameter:
     Type: "AWS::SSM::Parameter"
     Properties:
@@ -450,6 +468,15 @@ Resources:
       Type: String
       Description: Name of Step Functions workflow that orchestrates this process
       Value: !Ref StepFunctionName
+
+  MonoToStereoStepFunctionNameParameter:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: MonoToStereoStepFunctionName
+      Type: String
+      Description: Name of Step Functions workflow that orchestrates mono to stereo audio file converstion
+      Value: !Ref MonoToStereoStepFunctionName
+
 
   BulkUploadStepFunctionNameParameter:
     Type: "AWS::SSM::Parameter"

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-this is test file

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+this is test file


### PR DESCRIPTION
*Feature: Mono Audio file support for PCA*

Current PCA solution doesn't support mono audio files (single channel) for start_call_analytics_job api call. This code will check if uploaded audio file is mono or stereo. If it's mono then it will convert it to stereo and continue executing rest of the workflow.
This will help customer to analyze call center audio data which is mono file (single channel) with call analytics.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
