### PR TITLE
151 full custom kms support

### DIFF
--- a/aws-kendra-transcribe-media-search/cfn-templates/msfinder.yaml
+++ b/aws-kendra-transcribe-media-search/cfn-templates/msfinder.yaml
@@ -217,7 +217,29 @@ Resources:
                 Action:
                   - 's3:GetObject'                
           PolicyName: AWSMediaAppCredsPolicy
-      
+
+  BulkUploadBucketKmsKeyPolicy:
+    Condition: MediaBucketsEncrypted
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: BulkTemplateBulkUploadBucketCustomKey
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+              - "kms:CreateGrant"
+              - "kms:ListGrants"
+              - "kms:RevokeGrant"
+            Resource: !Ref MediaBucketKmsKeyArns
+      Roles:
+        - !Ref MediaAppCredsRole
+
   ##Create CodeCommit Repository for the code of the application
   Repository:
     Type: 'AWS::CodeCommit::Repository'
@@ -359,6 +381,7 @@ Resources:
       Param5: !Ref EnableAccessTokens
       Param6: !Ref EnableGuestUser
       Param7: !Ref AdminEmail
+      Param8: !Ref MediaBucketKmsKeyArns
   
   TokenEnablerLambdaRole:
     Type: AWS::IAM::Role
@@ -439,6 +462,11 @@ Parameters:
     Default: "<SAMPLES_BUCKET>"
     Description: >-
       (Required) A comma-delimited list of media bucket names - may include wildcards. Needed to support presigned URLs used to access media files contained in search results.
+  MediaBucketKmsKeyArns:
+    Type: CommaDelimitedList
+    Default: ''
+    Description: >-
+      (Optional) A comma-delimited list of media bucket KMS keys that encrypt the objects. Items in this list should be one-to-one with `MediaBucketNames`.
   AdminEmail:
     Type: String
     Description: 'To enable authentication please provide a valid email address for the admin user. This email address will be used for setting the admin password. This email will receive the temporary password for the admin user.'
@@ -464,6 +492,7 @@ Metadata:
               Parameters:
                   - KendraIndexId
                   - MediaBucketNames
+                  - MediaBucketKmsKeyArns
             - Label:
                 default: Authentication and access control parameters
               Parameters:
@@ -479,6 +508,10 @@ Conditions:
   EnableAccess: !Equals 
     - !Ref EnableAccessTokens
     - 'true'
+  MediaBucketsEncrypted: !Not
+    - !Equals
+      - !Join ['', !Ref MediaBucketKmsKeyArns]
+      - ''
     
 Outputs:
   MediaSearchFinderURL:

--- a/pca-main-nokendra.template
+++ b/pca-main-nokendra.template
@@ -22,8 +22,16 @@ Parameters:
     Default: ""
     Description: >-
       (Optional) Existing bucket where files can be dropped, and a secondary Step Function can be 
-      manually enabled to drip feed them into the system. 
+      manually enabled to drip feed them into the system.
       Leave blank to automatically create new bucket.
+
+  BulkUploadBucketKmsKeyArn:
+    Type: String
+    Default: ""
+    Description: >-
+      (Optional) KMS key to use to encrypt the bucket `BulkUploadBucketName`. If `BulkUploadBucketName` is empty,
+      use this key to encrypt the bucket this stack creates.
+      Leave blank to use S3 default encryption.
 
   BulkUploadMaxDripRate:
     Type: String
@@ -88,6 +96,14 @@ Parameters:
       (Optional) Existing bucket holding all audio files for the system. 
       Leave blank to automatically create new bucket with intelligent tiering storage and automated retention policy.
 
+  InputBucketKmsKeyArn:
+    Type: String
+    Default: ""
+    Description: >-
+      (Optional) KMS key to use to encrypt the bucket `InputBucketName`. If `InputBucketName` is empty,
+      use this key to encrypt the bucket this stack creates.
+      Leave blank to use S3 default encryption.
+
   InputBucketRawAudio:
     Type: String
     Default: originalAudio
@@ -121,6 +137,14 @@ Parameters:
     Description: >-
       (Optional) Existing bucket where Transcribe output files are delivered. 
       Leave blank to automatically create new bucket with intelligent tiering storage and automated retention policy.
+
+  OutputBucketKmsKeyArn:
+    Type: String
+    Default: ""
+    Description: >-
+      (Optional) KMS key to use to encrypt the bucket `OutputBucketName`. If `OutputBucketName` is empty,
+      use this key to encrypt the bucket this stack creates.
+      Leave blank to use S3 default encryption.
 
   OutputBucketTranscribeResults:
     Type: String
@@ -166,6 +190,14 @@ Parameters:
     Description: >-
       (Optional) Existing bucket that hold supporting files, such as the  file-based
       entity recognition mapping files.  Leave blank to automatically create new bucket.
+
+  SupportFilesBucketKmsKeyArn:
+    Type: String
+    Default: ""
+    Description: >-
+      (Optional) KMS key to use to encrypt the bucket `SupportFilesBucketName`. If `SupportFilesBucketName` is empty,
+      use this key to encrypt the bucket this stack creates.
+      Leave blank to use S3 default encryption.
 
   TranscribeLanguages:
     Type: String
@@ -355,6 +387,10 @@ Metadata:
                   - OutputBucketName
                   - SupportFilesBucketName
                   - RetentionDays
+                  - InputBucketKmsKeyArn
+                  - BulkUploadBucketKmsKeyArn
+                  - OutputBucketKmsKeyArn
+                  - SupportFilesBucketKmsKeyArn
             - Label:
                 default: S3 bucket prefixes
               Parameters:
@@ -407,11 +443,18 @@ Metadata:
 
 Conditions:
   ShouldCreateBulkUploadBucket: !Equals [!Ref BulkUploadBucketName, '']
+  ShouldEncryptBulkUploadBucketWithCmk: !Not [!Equals [!Ref BulkUploadBucketKmsKeyArn, '']]
   ShouldCreateInputBucket: !Equals [!Ref InputBucketName, '']
+  ShouldEncryptInputBucketWithCmk: !Not [!Equals [!Ref InputBucketKmsKeyArn, '']]
   ShouldCreateOutputBucket: !Equals [!Ref OutputBucketName, '']
+  ShouldEncryptOutputBucketWithCmk: !Not [!Equals [!Ref OutputBucketKmsKeyArn, '']]
   ShouldCreateSupportFilesBucket: !Equals [!Ref SupportFilesBucketName, '']
+  ShouldEncryptSupportFilesBucketWithCmk: !Not [!Equals [!Ref SupportFilesBucketKmsKeyArn, '']]
   ShouldEnableKendraSearch: !Not [!Equals [!Ref EnableTranscriptKendraSearch, 'No']]
   ShouldCreateKendraIndexDeveloperEdition: !Equals [!Ref EnableTranscriptKendraSearch, 'Yes, create new Kendra Index (Developer Edition)']
+
+# TODO: The web UI either needs to add a distribution for KMS in pca-ui/cfn/lib/web.template
+# or we need to add a rule to not allow the web UI and KMS keys
 
 Resources:
   ########################################################
@@ -423,24 +466,30 @@ Resources:
     Condition: ShouldCreateBulkUploadBucket
     Type: 'AWS::S3::Bucket'
     DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain 
+    UpdateReplacePolicy: Retain
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
+              !If
+              - ShouldEncryptBulkUploadBucketWithCmk
+              - { SSEAlgorithm: 'aws:kms', KMSMasterKeyID: !Ref BulkUploadBucketKmsKeyArn }
+              - { SSEAlgorithm: AES256 }
 
   InputBucket:
     Condition: ShouldCreateInputBucket
     Type: 'AWS::S3::Bucket'
     DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain 
+    UpdateReplacePolicy: Retain
     
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
+              !If
+              - ShouldEncryptInputBucketWithCmk
+              - { SSEAlgorithm: 'aws:kms', KMSMasterKeyID: !Ref InputBucketKmsKeyArn }
+              - { SSEAlgorithm: AES256 }
       LifecycleConfiguration:
         Rules:
           - Id: StorageClassAndRetention
@@ -459,7 +508,10 @@ Resources:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
+              !If
+              - ShouldEncryptOutputBucketWithCmk
+              - { SSEAlgorithm: 'aws:kms', KMSMasterKeyID: !Ref OutputBucketKmsKeyArn }
+              - { SSEAlgorithm: AES256 }
       LifecycleConfiguration:
         Rules:
           - Id: LifecycleRule
@@ -478,7 +530,10 @@ Resources:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
+              !If
+              - ShouldEncryptSupportFilesBucketWithCmk
+              - { SSEAlgorithm: 'aws:kms', KMSMasterKeyID: !Ref SupportFilesBucketKmsKeyArn }
+              - { SSEAlgorithm: AES256 }
 
 
   ########################################################
@@ -494,6 +549,11 @@ Resources:
           - ShouldCreateBulkUploadBucket
           - !Ref BulkUploadBucket
           - !Ref BulkUploadBucketName
+        BulkUploadBucketKmsKeyArn:
+          !If
+          - ShouldEncryptBulkUploadBucketWithCmk
+          - !Ref BulkUploadBucketKmsKeyArn
+          - AES256
         BulkUploadMaxDripRate: !Ref BulkUploadMaxDripRate
         BulkUploadMaxTranscribeJobs: !Ref BulkUploadMaxTranscribeJobs
         ComprehendLanguages: !Ref ComprehendLanguages
@@ -505,11 +565,16 @@ Resources:
         EntityTypes: !Ref EntityTypes
         InputBucketAudioPlayback: !Ref InputBucketAudioPlayback
         InputBucketFailedTranscriptions: !Ref InputBucketFailedTranscriptions
-        InputBucketName: 
+        InputBucketName:
           !If
           - ShouldCreateInputBucket
           - !Ref InputBucket
-          - !Ref InputBucketName        
+          - !Ref InputBucketName
+        InputBucketKmsKeyArn:
+          !If
+          - ShouldEncryptInputBucketWithCmk
+          - !Ref InputBucketKmsKeyArn
+          - AES256
         InputBucketRawAudio: !Ref InputBucketRawAudio
         InputBucketOrigTranscripts: !Ref InputBucketOrigTranscripts
         MaxSpeakers: !Ref MaxSpeakers
@@ -519,18 +584,28 @@ Resources:
           !If
           - ShouldCreateOutputBucket
           - !Ref OutputBucket
-          - !Ref OutputBucketName 
+          - !Ref OutputBucketName
+        OutputBucketKmsKeyArn:
+          !If
+          - ShouldEncryptOutputBucketWithCmk
+          - !Ref OutputBucketKmsKeyArn
+          - AES256
         OutputBucketTranscribeResults: !Ref OutputBucketTranscribeResults
         OutputBucketParsedResults: !Ref OutputBucketParsedResults
         SpeakerNames: !Ref SpeakerNames
         SpeakerSeparationType: !Ref SpeakerSeparationType
         StepFunctionName: !Ref StepFunctionName
         BulkUploadStepFunctionName: !Ref BulkUploadStepFunctionName
-        SupportFilesBucketName: 
+        SupportFilesBucketName:
           !If
           - ShouldCreateSupportFilesBucket
           - !Ref SupportFilesBucket
           - !Ref SupportFilesBucketName
+        SupportFilesBucketKmsKeyArn:
+          !If
+          - ShouldEncryptSupportFilesBucketWithCmk
+          - !Ref SupportFilesBucketKmsKeyArn
+          - AES256
         TranscribeLanguages: !Ref TranscribeLanguages
         TranscribeApiMode: !Ref TranscribeApiMode
         TelephonyCTRType: !Ref TelephonyCTRType
@@ -562,7 +637,7 @@ Resources:
       Parameters:
         ffmpegDownloadUrl: !Ref ffmpegDownloadUrl
         loadSampleAudioFiles: !Ref loadSampleAudioFiles
-      
+
   PCAUI:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -594,14 +669,30 @@ Outputs:
           - !Ref BulkUploadBucket
           - !Ref BulkUploadBucketName
 
+  BulkUploadBucketKmsKey:
+    Description: KMS key used to encrypt the BulkUploadBucket. Value of AES256 means default server side encryption is used.
+    Value:
+          !If
+          - ShouldEncryptBulkUploadBucketWithCmk
+          - !Ref BulkUploadBucketKmsKeyArn
+          - AES256
+
   InputBucket:
     Description: S3 Bucket for uploading input audio files
     Value:
       !If
       - ShouldCreateInputBucket
       - !Ref InputBucket
-      - !Ref InputBucketName  
-    
+      - !Ref InputBucketName
+
+  InputBucketKmsKey:
+    Description: KMS key used to encrypt the InputBucket. Value of AES256 means default server side encryption is used.
+    Value:
+          !If
+          - ShouldEncryptInputBucketWithCmk
+          - !Ref InputBucketKmsKeyArn
+          - AES256
+
   InputBucketPrefix:
     Description: S3 Bucket prefix/folder for uploading input audio files
     Value: !Ref InputBucketRawAudio
@@ -620,8 +711,16 @@ Outputs:
       !If
       - ShouldCreateOutputBucket
       - !Ref OutputBucket
-      - !Ref OutputBucketName  
-    
+      - !Ref OutputBucketName
+
+  OutputBucketKmsKey:
+    Description: KMS key used to encrypt the OutputBucket. Value of AES256 means default server side encryption is used.
+    Value:
+          !If
+          - ShouldEncryptOutputBucketWithCmk
+          - !Ref OutputBucketKmsKeyArn
+          - AES256
+
   OutputBucketPrefix:
     Description: S3 Bucket path where Transcribe output files are delivered
     Value: !Ref OutputBucketParsedResults
@@ -633,7 +732,15 @@ Outputs:
       - ShouldCreateSupportFilesBucket
       - !Ref SupportFilesBucket
       - !Ref SupportFilesBucketName  
-    
+
+  SupportFilesBucketKmsKey:
+    Description: KMS key used to encrypt the SupportFilesBucket. Value of AES256 means default server side encryption is used.
+    Value:
+          !If
+          - ShouldEncryptSupportFilesBucketWithCmk
+          - !Ref SupportFilesBucketKmsKeyArn
+          - AES256
+
   TranscriptionMediaSearchFinderURL:
     Description: Transcript Search Application link
     Value:

--- a/pca-main-nokendra.template
+++ b/pca-main-nokendra.template
@@ -454,7 +454,15 @@ Conditions:
   ShouldCreateKendraIndexDeveloperEdition: !Equals [!Ref EnableTranscriptKendraSearch, 'Yes, create new Kendra Index (Developer Edition)']
 
 # TODO: The web UI either needs to add a distribution for KMS in pca-ui/cfn/lib/web.template
-# or we need to add a rule to not allow the web UI and KMS keys
+# https://github.com/aws-samples/amazon-transcribe-post-call-analytics/pull/154 adds a flag for the GUI
+Rules:
+  WebNoKmsUsed:
+    RuleCondition: !Or
+      - !Not [!Equals [!Ref InputBucketKmsKeyArn, '']]
+      - !Not [!Equals [!Ref OutputBucketKmsKeyArn, '']]
+    Assertions:
+      - Assert: [!Equals ["true", "false"]]
+        AssertDescription: Input and Output buckets cannot use KMS encryption due to GUI limitations
 
 Resources:
   ########################################################

--- a/pca-main.template
+++ b/pca-main.template
@@ -456,7 +456,15 @@ Conditions:
   ShouldCreateKendraIndexDeveloperEdition: !Equals [!Ref EnableTranscriptKendraSearch, 'Yes, create new Kendra Index (Developer Edition)']
 
 # TODO: The web UI either needs to add a distribution for KMS in pca-ui/cfn/lib/web.template
-# or we need to add a rule to not allow the web UI and KMS keys
+# https://github.com/aws-samples/amazon-transcribe-post-call-analytics/pull/154 adds a flag for the GUI
+Rules:
+  WebNoKmsUsed:
+    RuleCondition: !Or
+      - !Not [!Equals [!Ref InputBucketKmsKeyArn, '']]
+      - !Not [!Equals [!Ref OutputBucketKmsKeyArn, '']]
+    Assertions:
+      - Assert: [!Equals ["true", "false"]]
+        AssertDescription: Input and Output buckets cannot use KMS encryption due to GUI limitations
 
 Resources:
   ########################################################

--- a/pca-main.template
+++ b/pca-main.template
@@ -8,11 +8,11 @@ Parameters:
     Type: String
     Default: "admin"
     Description: (Required) Username for admin user
-    
+
   AdminEmail:
       Type: String
       Description: >-
-        (Required) Email address for the admin user. Will be used for logging in and for setting the admin password. 
+        (Required) Email address for the admin user. Will be used for logging in and for setting the admin password.
         This email will receive the temporary password for the admin user.
       AllowedPattern: ".+\\@.+\\..+"
       ConstraintDescription: Must be valid email address eg. johndoe@example.com
@@ -21,9 +21,17 @@ Parameters:
     Type: String
     Default: ""
     Description: >-
-      (Optional) Existing bucket where files can be dropped, and a secondary Step Function can be 
-      manually enabled to drip feed them into the system. 
+      (Optional) Existing bucket where files can be dropped, and a secondary Step Function can be
+      manually enabled to drip feed them into the system.
       Leave blank to automatically create new bucket.
+
+  BulkUploadBucketKmsKeyArn:
+    Type: String
+    Default: ""
+    Description: >-
+      (Optional) KMS key to use to encrypt the bucket `BulkUploadBucketName`. If `BulkUploadBucketName` is empty,
+      use this key to encrypt the bucket this stack creates.
+      Leave blank to use S3 default encryption.
 
   BulkUploadMaxDripRate:
     Type: String
@@ -85,8 +93,16 @@ Parameters:
     Type: String
     Default: ""
     Description: >-
-      (Optional) Existing bucket holding all audio files for the system. 
+      (Optional) Existing bucket holding all audio files for the system.
       Leave blank to automatically create new bucket with intelligent tiering storage and automated retention policy.
+
+  InputBucketKmsKeyArn:
+    Type: String
+    Default: ""
+    Description: >-
+      (Optional) KMS key to use to encrypt the bucket `InputBucketName`. If `InputBucketName` is empty,
+      use this key to encrypt the bucket this stack creates.
+      Leave blank to use S3 default encryption.
 
   InputBucketRawAudio:
     Type: String
@@ -119,8 +135,16 @@ Parameters:
     Type: String
     Default: ""
     Description: >-
-      (Optional) Existing bucket where Transcribe output files are delivered. 
+      (Optional) Existing bucket where Transcribe output files are delivered.
       Leave blank to automatically create new bucket with intelligent tiering storage and automated retention policy.
+
+  OutputBucketKmsKeyArn:
+    Type: String
+    Default: ""
+    Description: >-
+      (Optional) KMS key to use to encrypt the bucket `OutputBucketName`. If `OutputBucketName` is empty,
+      use this key to encrypt the bucket this stack creates.
+      Leave blank to use S3 default encryption.
 
   OutputBucketTranscribeResults:
     Type: String
@@ -153,19 +177,27 @@ Parameters:
     AllowedPattern: "[-_a-zA-Z0-9]*"
     Default: PostCallAnalyticsWorkflow
     Description: Name of Step Functions workflow that orchestrates this process
-    
+
   BulkUploadStepFunctionName:
     Type: String
     AllowedPattern: "[-_a-zA-Z0-9]*"
     Default: BulkUploadWorkflow
     Description: Name of Step Functions workflow that orchestrates the bulk import process
-    
+
   SupportFilesBucketName:
     Type: String
     Default: ''
     Description: >-
       (Optional) Existing bucket that hold supporting files, such as the  file-based
       entity recognition mapping files.  Leave blank to automatically create new bucket.
+
+  SupportFilesBucketKmsKeyArn:
+    Type: String
+    Default: ""
+    Description: >-
+      (Optional) KMS key to use to encrypt the bucket `SupportFilesBucketName`. If `SupportFilesBucketName` is empty,
+      use this key to encrypt the bucket this stack creates.
+      Leave blank to use S3 default encryption.
 
   TranscribeLanguages:
     Type: String
@@ -242,13 +274,13 @@ Parameters:
         - true
         - false
     Description: Set to true to automatically ingest sample audio files.
-    
+
   FilenameDatetimeRegex:
     Type: String
     Default: '(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})'
     Description: >
-      Regular Expression (regex) used to parse call Date/Time from audio filenames. 
-      Each datetime field (year, month, etc.) must be matched using a separate parenthesized group in the regex. 
+      Regular Expression (regex) used to parse call Date/Time from audio filenames.
+      Each datetime field (year, month, etc.) must be matched using a separate parenthesized group in the regex.
       Example: the regex '(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})' parses
       the filename: CallAudioFile-2021-12-01T07-55-51.wav into a value list: [2021, 12, 01, 07, 55, 51]
       The next parameter, FilenameDatetimeFieldMap, maps the values to datetime field codes.
@@ -258,40 +290,40 @@ Parameters:
     Type: String
     Default: '%Y %m %d %H %M %S'
     Description: >
-      Space separated ordered sequence of time field codes as used by Python's datetime.strptime() function. 
-      Each field code refers to a corresponding value parsed by the regex parameter filenameTimestampRegex. 
+      Space separated ordered sequence of time field codes as used by Python's datetime.strptime() function.
+      Each field code refers to a corresponding value parsed by the regex parameter filenameTimestampRegex.
       Example: the mapping '%Y %m %d %H %M %S' assembles the regex output values [2021, 12, 01, 07, 55, 51]
-      into the full datetime: '2021-12-01 07:55:51'.  
+      into the full datetime: '2021-12-01 07:55:51'.
       If the field map doesn't match the value list parsed by the regex, then the current time is used as the call timestamp.
 
   FilenameGUIDRegex:
     Type: String
     Default: '_GUID_(.*?)_'
     Description: >
-      Regular Expression (regex) used to parse call GUID from audio filenames. 
-      The GUID value must be matched using one or more parenthesized groups in the regex. 
+      Regular Expression (regex) used to parse call GUID from audio filenames.
+      The GUID value must be matched using one or more parenthesized groups in the regex.
       Example: the regex '_GUID_(.*?)_' parses
-      the filename: AutoRepairs1_CUST_12345_GUID_2a602c1a-4ca3-4d37-a933-444d575c0222_AGENT_BobS_DATETIME_07.55.51.067-09-16-2021.wav 
+      the filename: AutoRepairs1_CUST_12345_GUID_2a602c1a-4ca3-4d37-a933-444d575c0222_AGENT_BobS_DATETIME_07.55.51.067-09-16-2021.wav
       to extract the GUID value '2a602c1a-4ca3-4d37-a933-444d575c0222'.
 
   FilenameAgentRegex:
     Type: String
     Default: '_AGENT_(.*?)_'
     Description: >
-      Regular Expression (regex) used to parse call AGENT from audio filenames. 
-      The AGENT value must be matched using one or more parenthesized groups in the regex. 
+      Regular Expression (regex) used to parse call AGENT from audio filenames.
+      The AGENT value must be matched using one or more parenthesized groups in the regex.
       Example: the regex '_AGENT_(.*?)_' parses
-      the filename: AutoRepairs1_CUST_12345_GUID_2a602c1a-4ca3-4d37-a933-444d575c0222_AGENT_BobS_DATETIME_07.55.51.067-09-16-2021.wav 
-      to extract the AGENT value 'BobS'. 
-  
+      the filename: AutoRepairs1_CUST_12345_GUID_2a602c1a-4ca3-4d37-a933-444d575c0222_AGENT_BobS_DATETIME_07.55.51.067-09-16-2021.wav
+      to extract the AGENT value 'BobS'.
+
   FilenameCustRegex:
     Type: String
     Default: '_CUST_(.*?)_'
     Description: >
-      Regular Expression (regex) used to parse Customer from audio filenames. 
-      The customer id value must be matched using one or more parenthesized groups in the regex. 
+      Regular Expression (regex) used to parse Customer from audio filenames.
+      The customer id value must be matched using one or more parenthesized groups in the regex.
       Example: the regex '_CUST_(.*?)_' parses
-      the filename: AutoRepairs1_CUST_12345_GUID_2a602c1a-4ca3-4d37-a933-444d575c0222_AGENT_BobS_DATETIME_07.55.51.067-09-16-2021.wav 
+      the filename: AutoRepairs1_CUST_12345_GUID_2a602c1a-4ca3-4d37-a933-444d575c0222_AGENT_BobS_DATETIME_07.55.51.067-09-16-2021.wav
       to extract the Customer value '12345'.
 
   EnableTranscriptKendraSearch:
@@ -315,7 +347,7 @@ Parameters:
       - 730
       - 1460
     Description: >
-      When using auto-provisioned S3 buckets, your audio files and associated call analysis data will be 
+      When using auto-provisioned S3 buckets, your audio files and associated call analysis data will be
       automatically and permanently deleted after the specified number of retention days. The application
       does not currently archive recordings or call data.
 
@@ -327,7 +359,7 @@ Parameters:
       - TEST
       - PROD
     Default: PROD
-    
+
   DatabaseName:
     Type: String
     Default: 'pca'
@@ -357,6 +389,10 @@ Metadata:
                   - OutputBucketName
                   - SupportFilesBucketName
                   - RetentionDays
+                  - InputBucketKmsKeyArn
+                  - BulkUploadBucketKmsKeyArn
+                  - OutputBucketKmsKeyArn
+                  - SupportFilesBucketKmsKeyArn
             - Label:
                 default: S3 bucket prefixes
               Parameters:
@@ -409,11 +445,18 @@ Metadata:
 
 Conditions:
   ShouldCreateBulkUploadBucket: !Equals [!Ref BulkUploadBucketName, '']
+  ShouldEncryptBulkUploadBucketWithCmk: !Not [!Equals [!Ref BulkUploadBucketKmsKeyArn, '']]
   ShouldCreateInputBucket: !Equals [!Ref InputBucketName, '']
+  ShouldEncryptInputBucketWithCmk: !Not [!Equals [!Ref InputBucketKmsKeyArn, '']]
   ShouldCreateOutputBucket: !Equals [!Ref OutputBucketName, '']
+  ShouldEncryptOutputBucketWithCmk: !Not [!Equals [!Ref OutputBucketKmsKeyArn, '']]
   ShouldCreateSupportFilesBucket: !Equals [!Ref SupportFilesBucketName, '']
+  ShouldEncryptSupportFilesBucketWithCmk: !Not [!Equals [!Ref SupportFilesBucketKmsKeyArn, '']]
   ShouldEnableKendraSearch: !Not [!Equals [!Ref EnableTranscriptKendraSearch, 'No']]
   ShouldCreateKendraIndexDeveloperEdition: !Equals [!Ref EnableTranscriptKendraSearch, 'Yes, create new Kendra Index (Developer Edition)']
+
+# TODO: The web UI either needs to add a distribution for KMS in pca-ui/cfn/lib/web.template
+# or we need to add a rule to not allow the web UI and KMS keys
 
 Resources:
   ########################################################
@@ -425,24 +468,29 @@ Resources:
     Condition: ShouldCreateBulkUploadBucket
     Type: 'AWS::S3::Bucket'
     DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain 
+    UpdateReplacePolicy: Retain
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
+              !If
+              - ShouldEncryptBulkUploadBucketWithCmk
+              - { SSEAlgorithm: 'aws:kms', KMSMasterKeyID: !Ref BulkUploadBucketKmsKeyArn }
+              - { SSEAlgorithm: AES256 }
 
   InputBucket:
     Condition: ShouldCreateInputBucket
     Type: 'AWS::S3::Bucket'
     DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain 
-    
+    UpdateReplacePolicy: Retain
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
+              !If
+              - ShouldEncryptInputBucketWithCmk
+              - { SSEAlgorithm: 'aws:kms', KMSMasterKeyID: !Ref InputBucketKmsKeyArn }
+              - { SSEAlgorithm: AES256 }
       LifecycleConfiguration:
         Rules:
           - Id: StorageClassAndRetention
@@ -456,12 +504,15 @@ Resources:
     Condition: ShouldCreateOutputBucket
     Type: 'AWS::S3::Bucket'
     DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain 
+    UpdateReplacePolicy: Retain
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
+              !If
+              - ShouldEncryptOutputBucketWithCmk
+              - { SSEAlgorithm: 'aws:kms', KMSMasterKeyID: !Ref OutputBucketKmsKeyArn }
+              - { SSEAlgorithm: AES256 }
       LifecycleConfiguration:
         Rules:
           - Id: LifecycleRule
@@ -475,12 +526,15 @@ Resources:
     Condition: ShouldCreateSupportFilesBucket
     Type: 'AWS::S3::Bucket'
     DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain 
+    UpdateReplacePolicy: Retain
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
+              !If
+              - ShouldEncryptSupportFilesBucketWithCmk
+              - { SSEAlgorithm: 'aws:kms', KMSMasterKeyID: !Ref SupportFilesBucketKmsKeyArn }
+              - { SSEAlgorithm: AES256 }
 
   ########################################################
   # Kendra Index
@@ -522,7 +576,7 @@ Resources:
                   - 'arn:aws:logs:${region}:${account}:log-group:/aws/kendra/*:log-stream:*'
                   - region: !Ref 'AWS::Region'
                     account: !Ref 'AWS::AccountId'
-                Action: 
+                Action:
                   - 'logs:DescribeLogStreams'
                   - 'logs:CreateLogStream'
                   - 'logs:PutLogEvents'
@@ -545,18 +599,18 @@ Resources:
       RoleArn: !GetAtt KendraIndexRole.Arn
       DocumentMetadataConfigurations:
         - Name: ANALYSIS_URI
-          Search: 
+          Search:
             Displayable: true
           Type: 'STRING_VALUE'
         - Name: DATETIME
-          Search: 
+          Search:
             Displayable: true
             Facetable: true
           Relevance:
             Freshness: true
           Type: 'DATE_VALUE'
         - Name: GUID
-          Search: 
+          Search:
             Displayable: true
             Searchable: true
           Type: 'STRING_VALUE'
@@ -566,32 +620,32 @@ Resources:
             Facetable: true
           Type: 'STRING_VALUE'
         - Name: DURATION
-          Search: 
+          Search:
             Displayable: true
             Facetable: true
           Type: 'STRING_VALUE'
         - Name: ENTITY_PERSON
-          Search: 
+          Search:
             Displayable: true
             Facetable: true
-          Type: 'STRING_LIST_VALUE'        
+          Type: 'STRING_LIST_VALUE'
         - Name: ENTITY_LOCATION
-          Search: 
+          Search:
             Displayable: true
             Facetable: true
           Type: 'STRING_LIST_VALUE'
         - Name: ENTITY_ORGANIZATION
-          Search: 
+          Search:
             Displayable: true
             Facetable: true
           Type: 'STRING_LIST_VALUE'
         - Name: ENTITY_COMMERCIAL_ITEM
-          Search: 
+          Search:
             Displayable: true
             Facetable: true
           Type: 'STRING_LIST_VALUE'
         - Name: ENTITY_EVENT
-          Search: 
+          Search:
             Displayable: true
             Facetable: true
           Type: 'STRING_LIST_VALUE'
@@ -612,7 +666,7 @@ Resources:
           Type: 'STRING_LIST_VALUE'
 
 
-  
+
   ########################################################
   # SSM Stack
   ########################################################
@@ -626,6 +680,11 @@ Resources:
           - ShouldCreateBulkUploadBucket
           - !Ref BulkUploadBucket
           - !Ref BulkUploadBucketName
+        BulkUploadBucketKmsKeyArn:
+          !If
+          - ShouldEncryptBulkUploadBucketWithCmk
+          - !Ref BulkUploadBucketKmsKeyArn
+          - AES256
         BulkUploadMaxDripRate: !Ref BulkUploadMaxDripRate
         BulkUploadMaxTranscribeJobs: !Ref BulkUploadMaxTranscribeJobs
         ComprehendLanguages: !Ref ComprehendLanguages
@@ -637,32 +696,47 @@ Resources:
         EntityTypes: !Ref EntityTypes
         InputBucketAudioPlayback: !Ref InputBucketAudioPlayback
         InputBucketFailedTranscriptions: !Ref InputBucketFailedTranscriptions
-        InputBucketName: 
+        InputBucketName:
           !If
           - ShouldCreateInputBucket
           - !Ref InputBucket
-          - !Ref InputBucketName        
+          - !Ref InputBucketName
+        InputBucketKmsKeyArn:
+          !If
+          - ShouldEncryptInputBucketWithCmk
+          - !Ref InputBucketKmsKeyArn
+          - AES256
         InputBucketRawAudio: !Ref InputBucketRawAudio
         InputBucketOrigTranscripts: !Ref InputBucketOrigTranscripts
         MaxSpeakers: !Ref MaxSpeakers
         MinSentimentNegative: !Ref MinSentimentNegative
         MinSentimentPositive: !Ref MinSentimentPositive
-        OutputBucketName: 
+        OutputBucketName:
           !If
           - ShouldCreateOutputBucket
           - !Ref OutputBucket
-          - !Ref OutputBucketName 
+          - !Ref OutputBucketName
+        OutputBucketKmsKeyArn:
+          !If
+          - ShouldEncryptOutputBucketWithCmk
+          - !Ref OutputBucketKmsKeyArn
+          - AES256
         OutputBucketTranscribeResults: !Ref OutputBucketTranscribeResults
         OutputBucketParsedResults: !Ref OutputBucketParsedResults
         SpeakerNames: !Ref SpeakerNames
         SpeakerSeparationType: !Ref SpeakerSeparationType
         StepFunctionName: !Ref StepFunctionName
         BulkUploadStepFunctionName: !Ref BulkUploadStepFunctionName
-        SupportFilesBucketName: 
+        SupportFilesBucketName:
           !If
           - ShouldCreateSupportFilesBucket
           - !Ref SupportFilesBucket
           - !Ref SupportFilesBucketName
+        SupportFilesBucketKmsKeyArn:
+          !If
+          - ShouldEncryptSupportFilesBucketWithCmk
+          - !Ref SupportFilesBucketKmsKeyArn
+          - AES256
         TranscribeLanguages: !Ref TranscribeLanguages
         TranscribeApiMode: !Ref TranscribeApiMode
         TelephonyCTRType: !Ref TelephonyCTRType
@@ -694,7 +768,7 @@ Resources:
       Parameters:
         ffmpegDownloadUrl: !Ref ffmpegDownloadUrl
         loadSampleAudioFiles: !Ref loadSampleAudioFiles
-      
+
   PCAUI:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -707,7 +781,7 @@ Resources:
           !If
           - ShouldCreateInputBucket
           - !Ref InputBucket
-          - !Ref InputBucketName 
+          - !Ref InputBucketName
         DataBucket:
           !If
           - ShouldCreateOutputBucket
@@ -729,7 +803,12 @@ Resources:
           - ShouldCreateInputBucket
           - !Ref InputBucket
           - !Ref InputBucketName
-        
+        MediaBucketKmsKeyArns:
+          !If
+            - ShouldEncryptInputBucketWithCmk
+            - !Ref InputBucketKmsKeyArn
+            - ''
+
 Outputs:
 
   BulkUploadBucket:
@@ -740,14 +819,30 @@ Outputs:
           - !Ref BulkUploadBucket
           - !Ref BulkUploadBucketName
 
+  BulkUploadBucketKmsKey:
+    Description: KMS key used to encrypt the BulkUploadBucket. Value of AES256 means default server side encryption is used.
+    Value:
+          !If
+          - ShouldEncryptBulkUploadBucketWithCmk
+          - !Ref BulkUploadBucketKmsKeyArn
+          - AES256
+
   InputBucket:
     Description: S3 Bucket for uploading input audio files
     Value:
       !If
       - ShouldCreateInputBucket
       - !Ref InputBucket
-      - !Ref InputBucketName  
-    
+      - !Ref InputBucketName
+
+  InputBucketKmsKey:
+    Description: KMS key used to encrypt the InputBucket. Value of AES256 means default server side encryption is used.
+    Value:
+          !If
+          - ShouldEncryptInputBucketWithCmk
+          - !Ref InputBucketKmsKeyArn
+          - AES256
+
   InputBucketPrefix:
     Description: S3 Bucket prefix/folder for uploading input audio files
     Value: !Ref InputBucketRawAudio
@@ -755,7 +850,7 @@ Outputs:
   InputBucketTranscriptPrefix:
     Description: S3 Bucket prefix/folder for uploading input transcripts
     Value: !Ref InputBucketOrigTranscripts
-  
+
   InputBucketPlaybackAudioPrefix:
     Description: S3 Bucket prefix/folder for audio used for playboack from browser
     Value: !Ref InputBucketAudioPlayback
@@ -766,8 +861,16 @@ Outputs:
       !If
       - ShouldCreateOutputBucket
       - !Ref OutputBucket
-      - !Ref OutputBucketName  
-    
+      - !Ref OutputBucketName
+
+  OutputBucketKmsKey:
+    Description: KMS key used to encrypt the OutputBucket. Value of AES256 means default server side encryption is used.
+    Value:
+          !If
+          - ShouldEncryptOutputBucketWithCmk
+          - !Ref OutputBucketKmsKeyArn
+          - AES256
+
   OutputBucketPrefix:
     Description: S3 Bucket path where Transcribe output files are delivered
     Value: !Ref OutputBucketParsedResults
@@ -778,8 +881,16 @@ Outputs:
       !If
       - ShouldCreateSupportFilesBucket
       - !Ref SupportFilesBucket
-      - !Ref SupportFilesBucketName  
-    
+      - !Ref SupportFilesBucketName
+
+  SupportFilesBucketKmsKey:
+    Description: KMS key used to encrypt the SupportFilesBucket. Value of AES256 means default server side encryption is used.
+    Value:
+          !If
+          - ShouldEncryptSupportFilesBucketWithCmk
+          - !Ref SupportFilesBucketKmsKeyArn
+          - AES256
+
   TranscriptionMediaSearchFinderURL:
     Description: Transcript Search Application link
     Value:
@@ -787,11 +898,11 @@ Outputs:
       - ShouldEnableKendraSearch
       - !GetAtt MediaSearchFinder.Outputs.MediaSearchFinderURL
       - "Not enabled"
- 
+
   WebAppURL:
     Description: PCA Web Application link
-    Value: !GetAtt PCAUI.Outputs.WebUri  
-    
+    Value: !GetAtt PCAUI.Outputs.WebUri
+
   WebAdminUsername:
     Description: PCA admin user
     Value: !Ref AdminUsername

--- a/pca-server/cfn/lib/boto3.template
+++ b/pca-server/cfn/lib/boto3.template
@@ -10,12 +10,18 @@ Parameters:
     Type: AWS::SSM::Parameter::Value<String>
     Default: SupportFilesBucketName
 
+  SupportFilesBucketKmsKeyArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: SupportFilesBucketKmsKey
+
   Boto3ZipName:
     Type: String
     Default: transcribeCallAnalyticsModels.zip
 
-Resources:
+Conditions:
+  SupportFilesBucketCustomKey: !Not [!Equals [!Ref SupportFilesBucketKmsKeyArn, 'AES256']]
 
+Resources:
   boto3ZipFunctionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -40,6 +46,28 @@ Resources:
                 Action:
                   - 's3:PutObject'
           PolicyName: boto3ZipFunctionS3Policy
+
+  SupportFilesBucketKmsKeyPolicy:
+    Condition: SupportFilesBucketCustomKey
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: Boto3TemplateSupportFilesBucketCustomKey
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+              - "kms:CreateGrant"
+              - "kms:ListGrants"
+              - "kms:RevokeGrant"
+            Resource: !Ref SupportFilesBucketKmsKeyArn
+      Roles:
+        - !Ref boto3ZipFunctionRole
 
   boto3ZipFunction:
     Type: AWS::Lambda::Function

--- a/pca-server/cfn/lib/bulk.template
+++ b/pca-server/cfn/lib/bulk.template
@@ -12,16 +12,28 @@ Parameters:
   BulkUploadBucketName:
     Type: AWS::SSM::Parameter::Value<String>
     Default: BulkUploadBucket
-    
+
+  BulkUploadBucketKmsKeyArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: BulkUploadBucketKmsKey
+
   InputBucketName:
     Type: AWS::SSM::Parameter::Value<String>
     Default: InputBucketName
+
+  InputBucketKmsKeyArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: InputBucketKmsKey
 
 Globals:
   Function:
     Runtime: python3.8
     MemorySize: 1024
     Timeout: 60
+
+Conditions:
+  BulkUploadBucketCustomKey: !Not [!Equals [!Ref BulkUploadBucketKmsKeyArn, 'AES256']]
+  InputBucketCustomKey: !Not [!Equals [!Ref InputBucketKmsKeyArn, 'AES256']]
 
 Resources:
   BulkFilesCount:
@@ -31,7 +43,7 @@ Resources:
       Handler: pca-aws-sf-bulk-files-count.lambda_handler
       Policies:
       - Statement:
-        - Sid: S3BucketReadPolicy    
+        - Sid: S3BucketReadPolicy
           Effect: Allow
           Action:
           - s3:ListBucket
@@ -40,7 +52,7 @@ Resources:
           - !Sub arn:aws:s3:::${BulkUploadBucketName}
           - !Sub arn:aws:s3:::${BulkUploadBucketName}/*
       - Statement:
-        - Sid: SSMGetParameterPolicy    
+        - Sid: SSMGetParameterPolicy
           Effect: Allow
           Action:
             - ssm:GetParameter
@@ -54,7 +66,7 @@ Resources:
       Timeout: 300
       Policies:
       - Statement:
-        - Sid: S3BucketReadWritePolicy    
+        - Sid: S3BucketReadWritePolicy
           Effect: Allow
           Action:
             - s3:ListBucket
@@ -67,6 +79,51 @@ Resources:
             - !Sub arn:aws:s3:::${InputBucketName}
             - !Sub arn:aws:s3:::${InputBucketName}/*
 
+  BulkUploadBucketKmsKeyPolicy:
+    Condition: BulkUploadBucketCustomKey
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: BulkTemplateBulkUploadBucketCustomKey
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+              - "kms:CreateGrant"
+              - "kms:ListGrants"
+              - "kms:RevokeGrant"
+            Resource: !Ref BulkUploadBucketKmsKeyArn
+      Roles:
+        - !Ref BulkFilesCountRole
+        - !Ref BulkMoveFilesRole
+
+  InputBucketKmsKeyPolicy:
+    Condition: InputBucketCustomKey
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: BulkTemplateInputBucketCustomKey
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+              - "kms:CreateGrant"
+              - "kms:ListGrants"
+              - "kms:RevokeGrant"
+            Resource: !Ref InputBucketKmsKeyArn
+      Roles:
+        - !Ref BulkMoveFilesRole
+
   BulkQueueSpace:
     Type: "AWS::Serverless::Function"
     Properties:
@@ -78,7 +135,7 @@ Resources:
 
   LogGroup:
     Type: AWS::Logs::LogGroup
-    Properties: 
+    Properties:
       LogGroupName: !Sub '/aws/vendedlogs/${BulkUploadStepFunctionName}'
       RetentionInDays: 90
 

--- a/pca-server/cfn/lib/copy-samples.template
+++ b/pca-server/cfn/lib/copy-samples.template
@@ -5,15 +5,21 @@ Description: Amazon Transcribe Post Call Analytics - PCA Server - Load sample au
 Transform: AWS::Serverless-2016-10-31
 
 Parameters:
-
-
   SupportFilesBucketName:
     Type: AWS::SSM::Parameter::Value<String>
     Default: SupportFilesBucketName
-    
+
+  SupportFilesBucketKmsKeyArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: SupportFilesBucketKmsKey
+
   InputBucketName:
     Type: AWS::SSM::Parameter::Value<String>
     Default: InputBucketName
+
+  InputBucketKmsKeyArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: InputBucketKmsKey
 
   InputBucketRawAudio:
     Type: AWS::SSM::Parameter::Value<String>
@@ -25,8 +31,11 @@ Globals:
     MemorySize: 1024
     Timeout: 60
 
-Resources:
+Conditions:
+  InputBucketCustomKey: !Not [!Equals [!Ref InputBucketKmsKeyArn, 'AES256']]
+  SupportFilesBucketCustomKey: !Not [!Equals [!Ref SupportFilesBucketKmsKeyArn, 'AES256']]
 
+Resources:
   CopySamplesRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -50,6 +59,49 @@ Resources:
                 - !Sub arn:aws:s3:::${InputBucketName}/*
                 - !Sub arn:aws:s3:::${SupportFilesBucketName}/*
 
+  InputBucketKmsKeyPolicy:
+    Condition: InputBucketCustomKey
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: CopySamplesTemplateInputBucketCustomKey
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+              - "kms:CreateGrant"
+              - "kms:ListGrants"
+              - "kms:RevokeGrant"
+            Resource: !Ref InputBucketKmsKeyArn
+      Roles:
+        - !Ref CopySamplesRole
+
+  SupportFilesBucketKmsKeyPolicy:
+    Condition: SupportFilesBucketCustomKey
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: CopySamplesTemplateSupportFilesBucketCustomKey
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+              - "kms:CreateGrant"
+              - "kms:ListGrants"
+              - "kms:RevokeGrant"
+            Resource: !Ref SupportFilesBucketKmsKeyArn
+      Roles:
+        - !Ref CopySamplesRole
 
   CopySamplesFunction:
     Type: "AWS::Lambda::Function"

--- a/pca-server/cfn/lib/ffmpeg.template
+++ b/pca-server/cfn/lib/ffmpeg.template
@@ -9,7 +9,11 @@ Parameters:
   SupportFilesBucketName:
     Type: AWS::SSM::Parameter::Value<String>
     Default: SupportFilesBucketName
-    
+
+  SupportFilesBucketKmsKeyArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: SupportFilesBucketKmsKey
+
   FFMPEGZipName:
     Type: String
     Default: ffmpeg.zip
@@ -18,10 +22,11 @@ Parameters:
     Type: String
     Default: https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
     Description: URL for ffmpeg binary distribution tar file download - see https://www.johnvansickle.com/ffmpeg/
-    
+
+Conditions:
+  SupportFilesBucketCustomKey: !Not [!Equals [!Ref SupportFilesBucketKmsKeyArn, 'AES256']]
 
 Resources:
-
   ffmpegZipFunctionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -46,6 +51,28 @@ Resources:
                 Action:
                   - 's3:PutObject'
           PolicyName: ffmpegZipFunctionS3Policy
+
+  SupportFilesBucketKmsKeyPolicy:
+    Condition: SupportFilesBucketCustomKey
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: FfmpegTemplateSupportFilesBucketCustomKey
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+              - "kms:CreateGrant"
+              - "kms:ListGrants"
+              - "kms:RevokeGrant"
+            Resource: !Ref SupportFilesBucketKmsKeyArn
+      Roles:
+        - !Ref ffmpegZipFunctionRole
 
   ffmpegZipFunction:
     Type: AWS::Lambda::Function

--- a/pca-server/cfn/lib/glue-database.template
+++ b/pca-server/cfn/lib/glue-database.template
@@ -13,13 +13,21 @@ Parameters:
   OutputBucketName:
     Type: AWS::SSM::Parameter::Value<String>
     Default: OutputBucketName
+
+  # TODO: Presumably a Glue DB crawler is needed to use S3 with KMS
+  # However, initial testing seems to show that this is not the case.
+  # OutputBucketKmsKeyArn:
+  #   Type: AWS::SSM::Parameter::Value<String>
+  #   Default: OutputBucketKmsKey
     
   OutputBucketParsedResults:
     Type: AWS::SSM::Parameter::Value<String>
     Default: OutputBucketParsedResults
 
-Resources:
+# Conditions:
+#   OutputBucketCustomKey: !Not [!Equals [!Ref OutputBucketKmsKeyArn, 'AES256']]
 
+Resources:
   Database:
     Type: AWS::Glue::Database
     Properties: 

--- a/pca-server/cfn/lib/matplotlib.template
+++ b/pca-server/cfn/lib/matplotlib.template
@@ -9,14 +9,19 @@ Parameters:
   SupportFilesBucketName:
     Type: AWS::SSM::Parameter::Value<String>
     Default: SupportFilesBucketName
-    
+
+  SupportFilesBucketKmsKeyArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: SupportFilesBucketKmsKey
+
   MPLZipName:
     Type: String
     Default: matplotlib-layer.zip
 
+Conditions:
+  SupportFilesBucketCustomKey: !Not [!Equals [!Ref SupportFilesBucketKmsKeyArn, 'AES256']]
 
 Resources:
-
   mplZipFunctionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -41,6 +46,28 @@ Resources:
                 Action:
                   - 's3:PutObject'
           PolicyName: mplZipFunctionS3Policy
+
+  SupportFilesBucketKmsKeyPolicy:
+    Condition: SupportFilesBucketCustomKey
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: MatplotlibTemplateSupportFilesBucketCustomKey
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+              - "kms:CreateGrant"
+              - "kms:ListGrants"
+              - "kms:RevokeGrant"
+            Resource: !Ref SupportFilesBucketKmsKeyArn
+      Roles:
+        - !Ref mplZipFunctionRole
 
   mplZipFunction:
     Type: AWS::Lambda::Function

--- a/pca-server/cfn/lib/pca.template
+++ b/pca-server/cfn/lib/pca.template
@@ -1,6 +1,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: Amazon Transcribe Post Call Analytics - PCA Server - PCA State Machine
+Description:
+  Amazon Transcribe Post Call Analytics - PCA Server - PCA State Machine
 
 Transform: AWS::Serverless-2016-10-31
 
@@ -26,19 +27,36 @@ Parameters:
     Type: AWS::SSM::Parameter::Value<String>
     Default: SupportFilesBucketName
 
+  SupportFilesBucketKmsKeyArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: SupportFilesBucketKmsKey
+
   StepFunctionName:
     Type: AWS::SSM::Parameter::Value<String>
     Default: StepFunctionName
-    
+
   InputBucketName:
     Type: AWS::SSM::Parameter::Value<String>
     Default: InputBucketName
+
+  InputBucketKmsKeyArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: InputBucketKmsKey
+
+  OutputBucketKmsKeyArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: OutputBucketKmsKey
 
 Globals:
   Function:
     Runtime: python3.8
     MemorySize: 1024
     Timeout: 60
+
+Conditions:
+  SupportFilesBucketCustomKey: !Not [!Equals [!Ref SupportFilesBucketKmsKeyArn, "AES256"]]
+  InputBucketCustomKey: !Not [!Equals [!Ref InputBucketKmsKeyArn, "AES256"]]
+  OutputBucketCustomKey: !Not [!Equals [!Ref OutputBucketKmsKeyArn, "AES256"]]
 
 Resources:
   FFMPEGLayer:
@@ -120,11 +138,10 @@ Resources:
                   - ssm:GetParameters
                 Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*
 
-
   SFStartTranscribeJob:
     Type: "AWS::Serverless::Function"
     Properties:
-      CodeUri:  ../../src/pca
+      CodeUri: ../../src/pca
       Handler: pca-aws-sf-start-transcribe-job.lambda_handler
       EphemeralStorage:
         Size: 4096
@@ -141,7 +158,7 @@ Resources:
   SFExtractJobHeader:
     Type: "AWS::Serverless::Function"
     Properties:
-      CodeUri:  ../../src/pca
+      CodeUri: ../../src/pca
       Handler: pca-aws-sf-extract-job-header.lambda_handler
       MemorySize: 1024
       Timeout: 900
@@ -158,7 +175,7 @@ Resources:
   SFExtractTranscriptHeader:
     Type: "AWS::Serverless::Function"
     Properties:
-      CodeUri:  ../../src/pca
+      CodeUri: ../../src/pca
       Handler: pca-aws-sf-extract-transcript-header.lambda_handler
       MemorySize: 1024
       Timeout: 900
@@ -175,7 +192,7 @@ Resources:
   SFProcessTurn:
     Type: "AWS::Serverless::Function"
     Properties:
-      CodeUri:  ../../src/pca
+      CodeUri: ../../src/pca
       Handler: pca-aws-sf-process-turn-by-turn.lambda_handler
       MemorySize: 1024
       Timeout: 900
@@ -196,7 +213,7 @@ Resources:
   SFFinalProcessing:
     Type: "AWS::Serverless::Function"
     Properties:
-      CodeUri:  ../../src/pca
+      CodeUri: ../../src/pca
       Handler: pca-aws-sf-post-processing.lambda_handler
       Layers:
         - !Ref Boto3Layer
@@ -210,7 +227,7 @@ Resources:
   SFCTRGenesys:
     Type: "AWS::Serverless::Function"
     Properties:
-      CodeUri:  ../../src/pca
+      CodeUri: ../../src/pca
       Handler: pca-aws-sf-ctr-genesys.lambda_handler
       Layers:
         - !Ref Boto3Layer
@@ -224,7 +241,7 @@ Resources:
   SFPostCTRProcessing:
     Type: "AWS::Serverless::Function"
     Properties:
-      CodeUri:  ../../src/pca
+      CodeUri: ../../src/pca
       Handler: pca-aws-sf-post-ctr-processing.lambda_handler
       Layers:
         - !Ref Boto3Layer
@@ -234,11 +251,11 @@ Resources:
       Policies:
         - arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess
         - arn:aws:iam::aws:policy/AmazonS3FullAccess
-        
+
   SFAwaitNotification:
     Type: "AWS::Serverless::Function"
     Properties:
-      CodeUri:  ../../src/pca
+      CodeUri: ../../src/pca
       Handler: pca-aws-sf-wait-for-transcribe-notification.lambda_handler
       Environment:
         Variables:
@@ -249,7 +266,7 @@ Resources:
   SFTranscribeFailed:
     Type: "AWS::Serverless::Function"
     Properties:
-      CodeUri:  ../../src/pca
+      CodeUri: ../../src/pca
       Handler: pca-aws-sf-transcribe-failed.lambda_handler
       Environment:
         Variables:
@@ -258,10 +275,91 @@ Resources:
         - arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess
         - arn:aws:iam::aws:policy/AmazonS3FullAccess
 
+  SupportFilesBucketKmsKeyPolicy:
+    Condition: SupportFilesBucketCustomKey
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: PcaTemplateSupportFilesBucketCustomKey
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+              - "kms:CreateGrant"
+              - "kms:ListGrants"
+              - "kms:RevokeGrant"
+            Resource: !Ref SupportFilesBucketKmsKeyArn
+      Roles:
+        - !Ref TranscribeRole
+        - !Ref TranscribeLambdaRole
+        - !Ref SFProcessTurnRole
+
+  InputBucketKmsKeyPolicy:
+    Condition: InputBucketCustomKey
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: PcaTemplateInputBucketCustomKey
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+              - "kms:CreateGrant"
+              - "kms:ListGrants"
+              - "kms:RevokeGrant"
+            Resource: !Ref InputBucketKmsKeyArn
+      Roles:
+        - !Ref TranscribeRole
+        - !Ref TranscribeLambdaRole
+        - !Ref SFExtractTranscriptHeaderRole
+        - !Ref SFProcessTurnRole
+        - !Ref SFCTRGenesysRole
+        - !Ref SFTranscribeFailedRole
+
+  OutputBucketKmsKeyPolicy:
+    Condition: OutputBucketCustomKey
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: PcaTemplateOutputBucketCustomKey
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+              - "kms:CreateGrant"
+              - "kms:ListGrants"
+              - "kms:RevokeGrant"
+            Resource: !Ref OutputBucketKmsKeyArn
+      Roles:
+        - !Ref TranscribeRole
+        - !Ref TranscribeLambdaRole
+        - !Ref SFExtractJobHeaderRole
+        - !Ref SFExtractTranscriptHeaderRole
+        - !Ref SFProcessTurnRole
+        - !Ref SFFinalProcessingRole
+        - !Ref SFCTRGenesysRole
+        - !Ref SFPostCTRProcessingRole
+        - !Ref SFTranscribeFailedRole
+
   LogGroup:
     Type: AWS::Logs::LogGroup
-    Properties: 
-      LogGroupName: !Sub '/aws/vendedlogs/${StepFunctionName}'
+    Properties:
+      LogGroupName: !Sub "/aws/vendedlogs/${StepFunctionName}"
       RetentionInDays: 90
 
   Role:
@@ -292,17 +390,17 @@ Resources:
         - PolicyName: CloudWatchLogs
           PolicyDocument:
             Statement:
-            - Effect: Allow
-              Action:
-              - logs:CreateLogDelivery
-              - logs:GetLogDelivery
-              - logs:UpdateLogDelivery
-              - logs:DeleteLogDelivery
-              - logs:ListLogDeliveries
-              - logs:PutResourcePolicy
-              - logs:DescribeResourcePolicies
-              - logs:DescribeLogGroups
-              Resource: "*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogDelivery
+                  - logs:GetLogDelivery
+                  - logs:UpdateLogDelivery
+                  - logs:DeleteLogDelivery
+                  - logs:ListLogDeliveries
+                  - logs:PutResourcePolicy
+                  - logs:DescribeResourcePolicies
+                  - logs:DescribeLogGroups
+                Resource: "*"
 
   StateMachine:
     Type: "AWS::StepFunctions::StateMachine"
@@ -328,10 +426,9 @@ Resources:
       RoleArn: !GetAtt Role.Arn
 
 Outputs:
-
   RolesForKMSKey:
     Value: !Join
-      - ', '
+      - ", "
       - - !Sub '"${TranscribeLambdaRole.Arn}"'
         - !Sub '"${TranscribeRole.Arn}"'
         - !Sub '"${SFProcessTurnRole.Arn}"'
@@ -339,4 +436,3 @@ Outputs:
         - !Sub '"${SFCTRGenesysRole.Arn}"'
         - !Sub '"${SFTranscribeFailedRole.Arn}"'
         - !Sub '"${SFPostCTRProcessingRole.Arn}"'
-

--- a/pca-server/cfn/lib/python-utilities.template
+++ b/pca-server/cfn/lib/python-utilities.template
@@ -10,13 +10,18 @@ Parameters:
     Type: AWS::SSM::Parameter::Value<String>
     Default: SupportFilesBucketName
 
+  SupportFilesBucketKmsKeyArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: SupportFilesBucketKmsKey
+
   PyZipName:
     Type: String
     Default: python-utils-layer.zip
 
+Conditions:
+  SupportFilesBucketCustomKey: !Not [!Equals [!Ref SupportFilesBucketKmsKeyArn, 'AES256']]
 
 Resources:
-
   PyUtilsZipFunctionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -41,6 +46,28 @@ Resources:
                 Action:
                   - 's3:PutObject'
           PolicyName: PyUtilsZipFunctionS3Policy
+
+  SupportFilesBucketKmsKeyPolicy:
+    Condition: SupportFilesBucketCustomKey
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: PythonUtilitiesTemplateSupportFilesBucketCustomKey
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+              - "kms:CreateGrant"
+              - "kms:ListGrants"
+              - "kms:RevokeGrant"
+            Resource: !Ref SupportFilesBucketKmsKeyArn
+      Roles:
+        - !Ref PyUtilsZipFunctionRole
 
   PyUtilZipFunction:
     Type: AWS::Lambda::Function

--- a/pca-server/cfn/lib/trigger.template
+++ b/pca-server/cfn/lib/trigger.template
@@ -18,6 +18,10 @@ Parameters:
     Type: AWS::SSM::Parameter::Value<String>
     Default: InputBucketName
 
+  InputBucketKmsKeyArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: InputBucketKmsKey
+
   InputBucketRawAudio:
     Type: AWS::SSM::Parameter::Value<String>
     Default: InputBucketRawAudio
@@ -36,6 +40,9 @@ Globals:
     MemorySize: 128
     Timeout: 15
 
+Conditions:
+  InputBucketCustomKey: !Not [!Equals [!Ref InputBucketKmsKeyArn, "AES256"]]
+
 Resources:
   FileDropTrigger:
     Type: "AWS::Serverless::Function"
@@ -48,7 +55,7 @@ Resources:
       Policies:
       - arn:aws:iam::aws:policy/AmazonTranscribeReadOnlyAccess
       - Statement:
-        - Sid: S3BucketReadPolicy    
+        - Sid: S3BucketReadPolicy
           Effect: Allow
           Action:
           - s3:ListBucket
@@ -57,7 +64,7 @@ Resources:
           - !Sub arn:aws:s3:::${InputBucketName}
           - !Sub arn:aws:s3:::${InputBucketName}/*
       - Statement:
-        - Sid: SSMGetParameterPolicy    
+        - Sid: SSMGetParameterPolicy
           Effect: Allow
           Action:
             - ssm:GetParameter
@@ -73,7 +80,28 @@ Resources:
           Action: states:StartExecution
           Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StepFunctionName}
 
-    
+  InputBucketKmsKeyPolicy:
+    Condition: InputBucketCustomKey
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: TriggerTemplateInputBucketCustomKey
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+              - "kms:CreateGrant"
+              - "kms:ListGrants"
+              - "kms:RevokeGrant"
+            Resource: !Ref InputBucketKmsKeyArn
+      Roles:
+        - !Ref FileDropTriggerRole
+
   FileDropTriggerPermission:
     Type: AWS::Lambda::Permission
     Properties:

--- a/pca-ssm/cfn/ssm.template
+++ b/pca-ssm/cfn/ssm.template
@@ -11,6 +11,13 @@ Parameters:
       manually enabled to drip feed them into the system. 
       Leave blank to automatically create new bucket.
 
+  BulkUploadBucketKmsKeyArn:
+    Type: String
+    Description: >-
+      (Optional) KMS key to use to encrypt the bucket `BulkUploadBucketName`. If `BulkUploadBucketName` is empty,
+      use this key to encrypt the bucket this stack creates.
+      Leave blank to use S3 default encryption.
+
   BulkUploadMaxDripRate:
     Type: String
     Default: "25"
@@ -72,6 +79,13 @@ Parameters:
       (Optional) Existing bucket holding all audio files for the system. 
       Leave blank to automatically create new bucket.
 
+  InputBucketKmsKeyArn:
+    Type: String
+    Description: >-
+      (Optional) KMS key to use to encrypt the bucket `InputBucketName`. If `InputBucketName` is empty,
+      use this key to encrypt the bucket this stack creates.
+      Leave blank to use S3 default encryption.
+
   InputBucketRawAudio:
     Type: String
     Default: originalAudio
@@ -104,6 +118,13 @@ Parameters:
     Description: >-
       (Optional) Existing bucket where Transcribe output files are delivered. 
       Leave blank to automatically create new bucket.
+
+  OutputBucketKmsKeyArn:
+    Type: String
+    Description: >-
+      (Optional) KMS key to use to encrypt the bucket `OutputBucketName`. If `OutputBucketName` is empty,
+      use this key to encrypt the bucket this stack creates.
+      Leave blank to use S3 default encryption.
 
   OutputBucketTranscribeResults:
     Type: String
@@ -143,6 +164,13 @@ Parameters:
       (Optional) Existing bucket that hold supporting files, such as the 
       file-based entity recognition mapping files. 
       Leave blank to automatically create new bucket.
+
+  SupportFilesBucketKmsKeyArn:
+    Type: String
+    Description: >-
+      (Optional) KMS key to use to encrypt the bucket `SupportFilesBucketName`. If `SupportFilesBucketName` is empty,
+      use this key to encrypt the bucket this stack creates.
+      Leave blank to use S3 default encryption.
 
   TranscribeApiMode:
     Type: String
@@ -265,6 +293,16 @@ Resources:
       Description: Bucket where files can be dropped, and a secondary Step Function can be manually enabled to drip feed them into the system
       Value: !Ref BulkUploadBucketName
 
+  BulkUploadBucketKmsKeyParameter:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: BulkUploadBucketKmsKey
+      Type: String
+      Description: >
+        Key Management Service Customer Managed Key ARN that encrypts the BulkUploadBucket.
+        The value AES256 means the default S3 server side encryption is used.
+      Value: !Ref BulkUploadBucketKmsKeyArn
+
   BulkUploadMaxDripRateParameter:
     Type: "AWS::SSM::Parameter"
     Properties:
@@ -361,6 +399,16 @@ Resources:
       Description: Bucket where where audio files are delivered
       Value: !Ref InputBucketName
 
+  InputBucketKmsKeyParameter:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: InputBucketKmsKey
+      Type: String
+      Description: >
+        Key Management Service Customer Managed Key ARN that encrypts the InputBucket.
+        The value AES256 means the default S3 server side encryption is used.
+      Value: !Ref InputBucketKmsKeyArn
+
   InputBucketRawAudioParameter:
     Type: "AWS::SSM::Parameter"
     Properties:
@@ -410,6 +458,16 @@ Resources:
       Type: String
       Description: Bucket where Transcribe output files are delivered
       Value: !Ref OutputBucketName
+
+  OutputBucketKmsKeyParameter:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: OutputBucketKmsKey
+      Type: String
+      Description: >
+        Key Management Service Customer Managed Key ARN that encrypts the OutputBucket.
+        The value AES256 means the default S3 server side encryption is used.
+      Value: !Ref OutputBucketKmsKeyArn
 
   OutputBucketTranscribeResultsParameter:
     Type: "AWS::SSM::Parameter"
@@ -466,6 +524,16 @@ Resources:
       Type: String
       Description: Bucket that hold supporting files, such as the file-based entity recognition mapping files
       Value: !Ref SupportFilesBucketName
+
+  SupportFilesBucketKmsKeyParameter:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: SupportFilesBucketKmsKey
+      Type: String
+      Description: >
+        Key Management Service Customer Managed Key ARN that encrypts the SupportFilesBucket.
+        The value AES256 means the default S3 server side encryption is used.
+      Value: !Ref SupportFilesBucketKmsKeyArn
 
   TranscribeApiModeParameter:
     Type: "AWS::SSM::Parameter"

--- a/pca-ui/cfn/lib/web.template
+++ b/pca-ui/cfn/lib/web.template
@@ -95,6 +95,7 @@ Resources:
             ResponseCode: 200
             ResponsePagePath: /index.html
 
+  # TODO: Add Lambda when using KMS for Data or Audio buckets
   ResponseHeaders:
     Type: AWS::CloudFront::ResponseHeadersPolicy
     Properties:


### PR DESCRIPTION
*Issue #, if available:* #151

*Description of changes:*

Adds explicit KMS custom key for S3 server side encryption into the template whenever a consumer creates a key and passes it in first.

Note that the Web UI needs a Lambda@Edge change to fully support this. We can get around this with the changes in #154, although most folks relying on the website will need to not encrypt the input and output buckets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
