### PR TITLE
Handle updates to the lambda layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 /sample-data
 .vscode
 /pca-ui/src/witch/witch.zip
+.DS_Store

--- a/pca-main-nokendra.template
+++ b/pca-main-nokendra.template
@@ -240,6 +240,21 @@ Parameters:
     Default: https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.4-amd64-static.tar.xz
     Description: URL for ffmpeg binary distribution tar file download - see https://www.johnvansickle.com/ffmpeg/
 
+  Boto3Version:
+    Type: String
+    Default: 'boto3==1.24.2'
+    Description: AWS SDK(Boto3) version for Python.
+
+  PythonUtilPipCommand:
+    Type: String
+    Default: 'pip install filetype==1.0.13 -t python'
+    Description: pip install command to create PythonUtil layer
+
+  MatplotlibPipCommand:
+    Type: String
+    Default: 'pip install numpy==1.19.4 matplotlib==3.3.3 --target python --only-binary=:all: --platform manylinux1_x86_64 --python=3.8'
+    Description: pip install command to create Matplotlib layer
+
   loadSampleAudioFiles:
     Type: String
     Default: false
@@ -600,6 +615,9 @@ Resources:
       TemplateURL: pca-server/cfn/pca-server.template
       Parameters:
         ffmpegDownloadUrl: !Ref ffmpegDownloadUrl
+        Boto3Version: !Ref Boto3Version
+        MatplotlibPipCommand: !Ref MatplotlibPipCommand
+        PythonUtilPipCommand: !Ref PythonUtilPipCommand
       
   PCAUI:
     Type: AWS::CloudFormation::Stack

--- a/pca-main.template
+++ b/pca-main.template
@@ -240,6 +240,21 @@ Parameters:
     Default: https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.4-amd64-static.tar.xz
     Description: URL for ffmpeg binary distribution tar file download - see https://www.johnvansickle.com/ffmpeg/
 
+  Boto3Version:
+    Type: String
+    Default: 'boto3==1.24.2'
+    Description: AWS SDK(Boto3) version for Python.
+
+  PythonUtilPipCommand:
+    Type: String
+    Default: 'pip install filetype==1.0.13 -t python'
+    Description: pip install command to create PythonUtil layer
+
+  MatplotlibPipCommand:
+    Type: String
+    Default: 'pip install numpy==1.19.4 matplotlib==3.3.3 --target python --only-binary=:all: --platform manylinux1_x86_64 --python=3.8'
+    Description: pip install command to create Matplotlib layer
+
   loadSampleAudioFiles:
     Type: String
     Default: false
@@ -731,6 +746,9 @@ Resources:
       TemplateURL: pca-server/cfn/pca-server.template
       Parameters:
         ffmpegDownloadUrl: !Ref ffmpegDownloadUrl
+        Boto3Version: !Ref Boto3Version
+        MatplotlibPipCommand: !Ref MatplotlibPipCommand
+        PythonUtilPipCommand: !Ref PythonUtilPipCommand
       
   PCAUI:
     Type: AWS::CloudFormation::Stack

--- a/pca-server/cfn/lib/boto3.template
+++ b/pca-server/cfn/lib/boto3.template
@@ -12,8 +12,12 @@ Parameters:
 
   Boto3ZipName:
     Type: String
-    Default: transcribeCallAnalyticsModels.zip
-
+    Default: transcribeCallAnalyticsModels
+  
+  Boto3Version:
+    Type: String
+    Default: 'boto3==1.24.2'
+  
 Resources:
 
   boto3ZipFunctionRole:
@@ -53,6 +57,7 @@ Resources:
         Variables:
           SUPPORT_FILES_BUCKET: !Ref SupportFilesBucketName
           BOTO3_ZIP_NAME: !Ref Boto3ZipName
+          BOTO3_VERSION: !Ref Boto3Version
       Code:
         ZipFile: |
           # Package up the Transcribe model version that we need from boto3 (missing from Lambda @ 10/1/2021)
@@ -66,8 +71,10 @@ Resources:
           import sys
           import shutil
           import subprocess
+          import uuid
           bucket = os.environ['SUPPORT_FILES_BUCKET']
           boto_zip_file_name = os.environ['BOTO3_ZIP_NAME']
+          boto_version = os.environ['BOTO3_VERSION']
           def handler(event, context):
             responseData={}
             status = cfnresponse.SUCCESS
@@ -90,13 +97,14 @@ Resources:
                   os.mkdir(root_path)
                 # Write out the requirements.txt file, which is the boto3 version we need
                 with open(reqs_file, 'w') as f:
-                  f.write("boto3==1.24.2")
+                  f.write(boto_version)
                   f.close()
                 # Install this version of boto3 locally and copy out Transcribe model
                 subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", reqs_file, "-t", pip_folder])
                 shutil.copy(f"{pip_folder}/botocore/data/{zip_subfolder_1}/{zip_subfolder_2}/service-2.json", "/".join(zip_folders))
                 # Zip up the models folder, maintaining the folder structure
-                with ZipFile(boto_zip_file_name, 'w') as zipObj:
+                output_zip_file_name = f"{boto_zip_file_name}-{str(uuid.uuid4())}.zip"
+                with ZipFile(output_zip_file_name, 'w') as zipObj:
                    for folderName, subfolders, filenames in os.walk(zip_folder):
                        for filename in filenames:
                            #create complete filepath of file in directory
@@ -105,9 +113,10 @@ Resources:
                            print(f"zipping {filePath}")
                            zipObj.write(filePath)
                 # Upload zipfile to S3
-                print(f"uploading {boto_zip_file_name} to s3 bucket {bucket}")
+                print(f"uploading {output_zip_file_name} to s3 bucket {bucket}")
                 s3_client = boto3.client('s3')
-                response = s3_client.upload_file(boto_zip_file_name, bucket, boto_zip_file_name)
+                response = s3_client.upload_file(output_zip_file_name, bucket, output_zip_file_name)
+                responseData["Boto3OutputZipFile"] = output_zip_file_name
               except Exception as e:
                   print(e)
                   responseData["Error"] = f"Exception thrown: {e}"
@@ -117,6 +126,7 @@ Resources:
   boto3Zip:
     Type: Custom::boto3Zip
     Properties:
+      Boto3Version: !Ref Boto3Version
       ServiceToken: !GetAtt boto3ZipFunction.Arn
 
   Boto3Layer:
@@ -125,10 +135,9 @@ Resources:
     Properties:
       Content:
         S3Bucket: !Ref SupportFilesBucketName
-        S3Key: !Ref Boto3ZipName
+        S3Key: !GetAtt boto3Zip.Boto3OutputZipFile
 
 Outputs:
-
   Boto3Layer:
     Description: Lambda layer for Boto3 that other Lambdas may need
     Value: !Ref Boto3Layer

--- a/pca-server/cfn/lib/boto3.template
+++ b/pca-server/cfn/lib/boto3.template
@@ -131,7 +131,6 @@ Resources:
 
   Boto3Layer:
     Type: "AWS::Lambda::LayerVersion"
-    DependsOn: boto3Zip
     Properties:
       Content:
         S3Bucket: !Ref SupportFilesBucketName

--- a/pca-server/cfn/lib/ffmpeg.template
+++ b/pca-server/cfn/lib/ffmpeg.template
@@ -115,6 +115,7 @@ Resources:
   ffmpegZip:
     Type: Custom::ffmpegZip
     Properties:
+      Downloadurl: !Ref ffmpegDownloadUrl
       ServiceToken: !GetAtt ffmpegZipFunction.Arn
       
 Outputs:

--- a/pca-server/cfn/lib/ffmpeg.template
+++ b/pca-server/cfn/lib/ffmpeg.template
@@ -12,7 +12,7 @@ Parameters:
     
   FFMPEGZipName:
     Type: String
-    Default: ffmpeg.zip
+    Default: ffmpeg
 
   ffmpegDownloadUrl:
     Type: String
@@ -66,6 +66,7 @@ Resources:
           import boto3
           import urllib.request
           import tarfile
+          import uuid
           from zipfile import ZipFile
           import cfnresponse
           url = os.environ['FFMPEG_DOWNLOAD_URL']
@@ -93,7 +94,8 @@ Resources:
                         tar.extract(member)
                 tar.close()
                 # zip the bin directory
-                with ZipFile(zip_file_name, 'w') as zipObj:
+                output_zip_file_name = f"{zip_file_name}-{str(uuid.uuid4())}.zip"
+                with ZipFile(output_zip_file_name, 'w') as zipObj:
                    for folderName, subfolders, filenames in os.walk(bin_dir):
                        for filename in filenames:
                            #create complete filepath of file in directory
@@ -102,9 +104,10 @@ Resources:
                            print(f"zipping {filePath}")
                            zipObj.write(filePath)
                 # Upload zipfile to S3
-                print(f"uploading {zip_file_name} to s3 bucket {bucket}")
+                print(f"uploading {output_zip_file_name} to s3 bucket {bucket}")
                 s3_client = boto3.client('s3')
-                response = s3_client.upload_file(zip_file_name, bucket, zip_file_name)
+                response = s3_client.upload_file(output_zip_file_name, bucket, output_zip_file_name)
+                responseData["FfmpeqOutputZipFile"] = output_zip_file_name
               except Exception as e:
                   print(e)
                   responseData["Error"] = f"Exception thrown: {e}"
@@ -120,4 +123,4 @@ Resources:
       
 Outputs:
   FFMPEGZipName:
-    Value: !Ref FFMPEGZipName
+    Value: !GetAtt ffmpegZip.FfmpeqOutputZipFile

--- a/pca-server/cfn/lib/matplotlib.template
+++ b/pca-server/cfn/lib/matplotlib.template
@@ -12,7 +12,11 @@ Parameters:
     
   MPLZipName:
     Type: String
-    Default: matplotlib-layer.zip
+    Default: matplotlib-layer
+
+  MatplotlibPipCommand:
+    Type: String
+    Default: 'pip install numpy==1.19.4 matplotlib==3.3.3 --target python --only-binary=:all: --platform manylinux1_x86_64 --python=3.8'
 
 
 Resources:
@@ -54,6 +58,7 @@ Resources:
         Variables:
           SUPPORT_FILES_BUCKET: !Ref SupportFilesBucketName
           MPL_ZIP_NAME: !Ref MPLZipName
+          PIP_COMMAND: !Ref MatplotlibPipCommand
       Code:
         ZipFile: |
           import os
@@ -62,10 +67,12 @@ Resources:
           import subprocess
           import shutil
           import cfnresponse
+          import uuid
           def handler(event, context):
             # Read off our env values
             bucket = os.environ['SUPPORT_FILES_BUCKET']
             zip_file_name = os.environ['MPL_ZIP_NAME']
+            pip_command = os.environ['PIP_COMMAND']
             responseData = {}
             status = cfnresponse.SUCCESS
             if event['RequestType'] != 'Delete':
@@ -75,24 +82,21 @@ Resources:
                 shutil.rmtree("python", ignore_errors=True)
                 os.mkdir("python")
                 # Download the libraries we need via pip
-                subprocess.run(["pip", "install",
-                                "numpy==1.19.4", "matplotlib==3.3.3",
-                                "--target", "python",
-                                "--only-binary=:all:",
-                                "--platform", "manylinux1_x86_64",
-                                "--python=3.8"], check=True)
+                subprocess.run([*pip_command.split()], check=True)
                 # Zip up what we downloaded
-                with ZipFile(zip_file_name, 'w') as zipObj:
-                  print(f"Creating zip file {zip_file_name} for upload...")
+                output_zip_file_name = f"{zip_file_name}-{str(uuid.uuid4())}.zip"
+                with ZipFile(output_zip_file_name, 'w') as zipObj:
+                  print(f"Creating zip file {output_zip_file_name} for upload...")
                   for folderName, subfolders, filenames in os.walk("python"):
                     for filename in filenames:
                       # create complete filepath of file in directory
                       filePath = os.path.join(folderName, filename)
                       zipObj.write(filePath)
                 # Upload zipfile to S3
-                print(f"Uploading {zip_file_name} to s3 bucket {bucket}...")
+                print(f"Uploading {output_zip_file_name} to s3 bucket {bucket}...")
                 s3_client = boto3.client('s3')
-                response = s3_client.upload_file(zip_file_name, bucket, zip_file_name)
+                response = s3_client.upload_file(output_zip_file_name, bucket, output_zip_file_name)
+                responseData["MplOutputZipFile"] = output_zip_file_name
               except Exception as e:
                 print(e)
                 responseData["Error"] = f"Exception thrown: {e}"
@@ -104,7 +108,8 @@ Resources:
     Type: Custom::mplZip
     Properties:
       ServiceToken: !GetAtt mplZipFunction.Arn
+      PipCommand: !Ref MatplotlibPipCommand
       
 Outputs:
   MPLZipName:
-    Value: !Ref MPLZipName
+    Value: !GetAtt mplZip.MplOutputZipFile

--- a/pca-server/cfn/lib/python-utilities.template
+++ b/pca-server/cfn/lib/python-utilities.template
@@ -12,8 +12,11 @@ Parameters:
 
   PyZipName:
     Type: String
-    Default: python-utils-layer.zip
+    Default: python-utils-layer
 
+  PythonUtilPipCommand:
+    Type: String
+    Default: 'pip install filetype==1.0.13 -t python'
 
 Resources:
 
@@ -54,6 +57,7 @@ Resources:
         Variables:
           SUPPORT_FILES_BUCKET: !Ref SupportFilesBucketName
           PY_ZIP_NAME: !Ref PyZipName
+          PIP_COMMAND: !Ref PythonUtilPipCommand
       Code:
         ZipFile: |
           import os
@@ -62,10 +66,12 @@ Resources:
           import subprocess
           import shutil
           import cfnresponse
+          import uuid
           def handler(event, context):
             # Read off our env values
             bucket = os.environ['SUPPORT_FILES_BUCKET']
             zip_file_name = os.environ['PY_ZIP_NAME']
+            pip_command = os.environ['PIP_COMMAND']
             responseData = {}
             status = cfnresponse.SUCCESS
             if event['RequestType'] != 'Delete':
@@ -75,21 +81,21 @@ Resources:
                 shutil.rmtree("python", ignore_errors=True)
                 os.mkdir("python")
                 # PIP - Install fileutil
-                subprocess.run(["pip", "install",
-                                "filetype==1.0.13",
-                                "-t", "python"], check=True)
+                subprocess.run([*pip_command.split()], check=True)
                 # Zip up everything that we downloaded
-                with ZipFile(zip_file_name, 'w') as zipObj:
-                  print(f"Creating zip file {zip_file_name} for upload...")
+                output_zip_file_name = f"{zip_file_name}-{str(uuid.uuid4())}.zip"
+                with ZipFile(output_zip_file_name, 'w') as zipObj:
+                  print(f"Creating zip file {output_zip_file_name} for upload...")
                   for folderName, subfolders, filenames in os.walk("python"):
                     for filename in filenames:
                       # create complete filepath of file in directory
                       filePath = os.path.join(folderName, filename)
                       zipObj.write(filePath)
                 # Upload zipfile to S3
-                print(f"Uploading {zip_file_name} to s3 bucket {bucket}...")
+                print(f"Uploading {output_zip_file_name} to s3 bucket {bucket}...")
                 s3_client = boto3.client('s3')
-                response = s3_client.upload_file(zip_file_name, bucket, zip_file_name)
+                response = s3_client.upload_file(output_zip_file_name, bucket, output_zip_file_name)
+                responseData["PyOutputZipFile"] = output_zip_file_name
               except Exception as e:
                 print(e)
                 responseData["Error"] = f"Exception thrown: {e}"
@@ -100,6 +106,7 @@ Resources:
     Type: Custom::PyUtilsZip
     Properties:
       ServiceToken: !GetAtt PyUtilZipFunction.Arn
+      PipCommand: !Ref PythonUtilPipCommand
 
   PyUtilsLayer:
     Type: "AWS::Lambda::LayerVersion"
@@ -112,11 +119,11 @@ Resources:
         - python3.9
       Content:
         S3Bucket: !Ref SupportFilesBucketName
-        S3Key: !Ref PyZipName
+        S3Key: !GetAtt PyUtilsZip.PyOutputZipFile
 
 Outputs:
   PyZipName:
-    Value: !Ref PyZipName
+    Value: !GetAtt PyUtilsZip.PyOutputZipFile
 
   PyUtilsLayer:
     Description: Lambda layer for Python utils that other Lambdas may need

--- a/pca-server/cfn/lib/python-utilities.template
+++ b/pca-server/cfn/lib/python-utilities.template
@@ -110,7 +110,6 @@ Resources:
 
   PyUtilsLayer:
     Type: "AWS::Lambda::LayerVersion"
-    DependsOn: PyUtilsZip
     Properties:
       CompatibleArchitectures:
         - x86_64

--- a/pca-server/cfn/pca-server.template
+++ b/pca-server/cfn/pca-server.template
@@ -7,6 +7,21 @@ Parameters:
     Type: String
     Default: https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
     Description: URL for ffmpeg binary distribution tar file download - see https://www.johnvansickle.com/ffmpeg/
+  
+  Boto3Version:
+    Type: String
+    Default: 'boto3==1.24.2'
+    Description: AWS SDK(Boto3) version for Python.
+
+  PythonUtilPipCommand:
+    Type: String
+    Default: 'pip install filetype==1.0.13 -t python'
+    Description: pip install command to create PythonUtil layer
+
+  MatplotlibPipCommand:
+    Type: String
+    Default: 'pip install numpy==1.19.4 matplotlib==3.3.3 --target python --only-binary=:all: --platform manylinux1_x86_64 --python=3.8'
+    Description: pip install command to create Matplotlib layer
 
 Resources:
   FFMPEG:
@@ -20,16 +35,23 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: lib/matplotlib.template
+      Parameters:
+        MatplotlibPipCommand: !Ref MatplotlibPipCommand
 
   BOTO3:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: lib/boto3.template
+      Parameters:
+        Boto3Version: !Ref Boto3Version
+
 
   PYTHONUTILS:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: lib/python-utilities.template
+      Parameters:
+        PythonUtilPipCommand: !Ref PythonUtilPipCommand
 
   DDB:
     Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
*Issue #, if available:*

Solution deploys multiple Custom CFN resource to build lambda layers. The initial deployment works fine, but subsequent updates to the layer custom resources are not handled appropriately. For instance, if an update is made to the version of a package such as `matplotlib` by updating the `mplZipFunction` function code, it does not trigger the `mplZip` custom resource to execute the function to install and create a new Zip artifact. Furthermore, a new Layer is not created by MPLLayer as nothing changes in the resource properties.

*Description of changes:*

This pull request updates the CFN templates for Lambda layers to improve the layer creation/update process. The updated templates create some new CFN parameters to allows users to specify the package versions or pip installation command. Changes/update to these parameters will trigger the creation of a new layer, ensuring that users can update/change the layers without manual efforts. This resolves the issue of updates not triggering the custom resource to execute and create a new layer when package/installation commands are updated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
