### PR TITLE
CloudFormation pca-ui web LogBucket ACL change

### DIFF
--- a/pca-ui/cfn/lib/web.template
+++ b/pca-ui/cfn/lib/web.template
@@ -48,7 +48,11 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-      AccessControl: LogDeliveryWrite
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
 
   WebBucketPolicy:
     Type: "AWS::S3::BucketPolicy"


### PR DESCRIPTION
Issue #163 :

The stack fails to deploy in either of the supported regions. Info from the failed stack is:

The following resource(s) failed to create: `[LogBucket]`.

`Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting (Service: Amazon S3; Status Code: 400; Error Code: InvalidBucketAclWithObjectOwnership;`

*Description of changes:*

Modified the `web.template` in the `pca-ui`:
In the LogBucket declaration:

- Removed `AccessControl: LogDeliveryWrite`
- Added:
`PublicAccessBlockConfiguration:
        BlockPublicAcls: false
      OwnershipControls:
        Rules:
          - ObjectOwnership: ObjectWriter`

This change fixes the deployment of the stack when published **privately**. 
More changes are needed in `publish.sh` and `publish-nokendra.sh` to fix similar issues with the `put-object-acl --acl public-read` action when `ACL="public"`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
