### PR TITLE
update to nodejs 14

### DIFF
--- a/pca-server/cfn/lib/trigger.template
+++ b/pca-server/cfn/lib/trigger.template
@@ -110,7 +110,7 @@ Resources:
     Properties:
       Code:  ../../src/trigger
       Handler: index.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Role: !GetAtt ConfigureBucketRole.Arn
       Environment:
         Variables:

--- a/pca-ui/cfn/lib/deploy.template
+++ b/pca-ui/cfn/lib/deploy.template
@@ -26,7 +26,7 @@ Resources:
     Type: "AWS::Lambda::LayerVersion"
     Properties:
       CompatibleRuntimes:
-        - nodejs12.x
+        - nodejs14.x
       Content: ../../src/witch/witch.zip
 
   Role:
@@ -70,7 +70,7 @@ Resources:
       Layers:
         - !Ref Layer
       Role: !GetAtt Role.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Timeout: 300
 
   ConfigureFunction:
@@ -79,7 +79,7 @@ Resources:
       Code: ../../src/lambda
       Handler: config.handler
       Role: !GetAtt Role.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
 
   Deploy:
     Type: "AWS::CloudFormation::CustomResource"

--- a/pca-ui/cfn/lib/indexer.template
+++ b/pca-ui/cfn/lib/indexer.template
@@ -61,7 +61,7 @@ Resources:
     Properties:
       Code:  ../../src/lambda
       Handler: bucket.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Role: !GetAtt ConfigureDataBucketRole.Arn
       Environment:
         Variables:
@@ -122,7 +122,7 @@ Resources:
             TableName: !Ref Table
         - S3ReadPolicy:
             BucketName: !Ref DataBucket
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
 
 Outputs:
   TableName:


### PR DESCRIPTION
*Issue #, if available:* 

NodeJS 12 is deprecated, moving to 14 to maintain backwards until we update Lambdas for 18x. 

*Description of changes:*

This update has been deployed several times.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
