### PR TITLE
Test that Bedrock service and selected models are available in account during stack create/update to avoid downstream failures

### DIFF
--- a/pca-main-nokendra.template
+++ b/pca-main-nokendra.template
@@ -539,6 +539,9 @@ Conditions:
   ShouldLoadSampleFiles: !Equals [!Ref loadSampleAudioFiles, 'true']
   ShouldDeployBedrockBoto3Layer: !Or [!Equals [!Ref CallSummarization, 'BEDROCK'], !Equals [!Ref GenAIQuery, 'BEDROCK'],]
   ShouldDeployLLMThirdPartyApiKey: !And [!Not [!Equals [!Ref SummarizationLLMThirdPartyApiKey, '']], !Not [!Equals [!Ref SummarizationLLMThirdPartyApiKey, undefined]]]
+  ShouldTestBedrockModelId: !Or [!Equals [!Ref CallSummarization, 'BEDROCK'], !Equals [!Ref GenAIQuery, 'BEDROCK'],]
+  ShouldTestGenAIQueryBedrockModelId: !Equals [!Ref GenAIQuery, 'BEDROCK']
+  ShouldTestSummarizationBedrockModelId: !Equals [!Ref CallSummarization, 'BEDROCK']
 
 Resources:
   ########################################################
@@ -607,6 +610,153 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
 
+  ########################################################
+  # If Bedrock Models are selected, verify that Bedrock 
+  # is avialble in the region, and that models are enabled
+  ########################################################
+
+  TestBedrockModelFunctionRole:
+    Type: AWS::IAM::Role
+    Condition: ShouldTestBedrockModelId
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "bedrock:InvokeModel"
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:bedrock:*::foundation-model/*"
+                  - !Sub "arn:${AWS::Partition}:bedrock:*:${AWS::AccountId}:custom-model/*"
+          PolicyName: BedrockPolicy
+
+  TestBedrockModelFunction:
+    Type: AWS::Lambda::Function
+    Condition: ShouldTestBedrockModelId
+    Properties:
+      Handler: index.lambda_handler
+      Role: !GetAtt 'TestBedrockModelFunctionRole.Arn'
+      Runtime: python3.11
+      Timeout: 60
+      MemorySize: 128
+      Code: 
+        ZipFile: !Sub |
+          import cfnresponse
+          import json
+          import subprocess
+          import os
+          import sys
+          print("install latest boto3 to get bedrock service support")
+          subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--target', '/tmp', 'boto3'])
+          sys.path.insert(0,'/tmp')
+          import boto3
+
+          # Defaults
+          AWS_REGION = os.environ["AWS_REGION_OVERRIDE"] if "AWS_REGION_OVERRIDE" in os.environ else os.environ["AWS_REGION"]
+          ENDPOINT_URL = os.environ.get("ENDPOINT_URL", f'https://bedrock-runtime.{AWS_REGION}.amazonaws.com')
+          DEFAULT_MAX_TOKENS = 128
+
+          def get_request_body(modelId, parameters, prompt):
+              provider = modelId.split(".")[0]
+              request_body = None
+              if provider == "anthropic":
+                  request_body = {
+                      "prompt": prompt,
+                      "max_tokens_to_sample": DEFAULT_MAX_TOKENS
+                  } 
+                  request_body.update(parameters)
+              elif provider == "ai21":
+                  request_body = {
+                      "prompt": prompt,
+                      "maxTokens": DEFAULT_MAX_TOKENS
+                  }
+                  request_body.update(parameters)
+              elif provider == "amazon":
+                  textGenerationConfig = {
+                      "maxTokenCount": DEFAULT_MAX_TOKENS
+                  }
+                  textGenerationConfig.update(parameters)
+                  request_body = {
+                      "inputText": prompt,
+                      "textGenerationConfig": textGenerationConfig
+                  }
+              else:
+                  raise Exception("Unsupported provider: ", provider)
+              return request_body
+
+          def get_generate_text(modelId, response):
+              provider = modelId.split(".")[0]
+              generated_text = None
+              if provider == "anthropic":
+                  response_body = json.loads(response.get("body").read().decode())
+                  generated_text = response_body.get("completion")
+              elif provider == "ai21":
+                  response_body = json.loads(response.get("body").read())
+                  generated_text = response_body.get("completions")[0].get("data").get("text")
+              elif provider == "amazon":
+                  response_body = json.loads(response.get("body").read())
+                  generated_text = response_body.get("results")[0].get("outputText")
+              else:
+                  raise Exception("Unsupported provider: ", provider)
+              return generated_text
+
+          def call_llm(parameters, prompt):
+              modelId = parameters.pop("modelId")
+              body = get_request_body(modelId, parameters, prompt)
+              print("ModelId", modelId, "-  Body: ", body)
+              client = boto3.client(service_name='bedrock-runtime', region_name=AWS_REGION, endpoint_url=ENDPOINT_URL)
+              response = client.invoke_model(body=json.dumps(body), modelId=modelId, accept='application/json', contentType='application/json')
+              generated_text = get_generate_text(modelId, response)
+              return generated_text
+
+          def lambda_handler(event, context):
+              print("Event: ", json.dumps(event))
+              global client
+              status = cfnresponse.SUCCESS
+              responseData = {}
+              reason = "Success"
+              modelId = ""
+              if event['RequestType'] != 'Delete':
+                  prompt = "\n\nHuman: Why is the sky blue?\n\nAssistant:"
+                  try:
+                      # Test LLMModel
+                      llmModelId = event['ResourceProperties'].get('LLMModelId', '')
+                      modelId = llmModelId
+                      parameters = {
+                          "modelId": modelId,
+                          "temperature": 0
+                      }
+                      print(f"Testing {modelId}")
+                      call_llm(parameters, prompt)            
+                  except Exception as e:
+                      status = cfnresponse.FAILED
+                      reason = f"Exception thrown testing ModelId='{modelId}'. Check that Amazon Bedrock is available in your region, and that model is activated in your Amazon Bedrock account - {e}"
+              print(f"Status: {status}, Reason: {reason}")        
+              cfnresponse.send(event, context, status, responseData, reason=reason)
+
+  TestGenAIQueryBedrockModelId:
+    Type: Custom::TestGenAIQueryBedrockModelId
+    Condition: ShouldTestGenAIQueryBedrockModelId
+    Properties:
+      ServiceToken: !GetAtt TestBedrockModelFunction.Arn
+      LLMModelId: !Ref GenAIQueryBedrockModelId
+
+  TestSummarizationBedrockModelId:
+    Type: Custom::SummarizationBedrockModelId
+    Condition: ShouldTestSummarizationBedrockModelId
+    Properties:
+      ServiceToken: !GetAtt TestBedrockModelFunction.Arn
+      LLMModelId: !Ref SummarizationBedrockModelId
 
   ########################################################
   # SSM Stack

--- a/pca-main.template
+++ b/pca-main.template
@@ -541,6 +541,10 @@ Conditions:
   ShouldLoadSampleFiles: !Equals [!Ref loadSampleAudioFiles, 'true']
   ShouldDeployBedrockBoto3Layer: !Or [!Equals [!Ref CallSummarization, 'BEDROCK'], !Equals [!Ref GenAIQuery, 'BEDROCK'],]
   ShouldDeployLLMThirdPartyApiKey: !And [!Not [!Equals [!Ref SummarizationLLMThirdPartyApiKey, '']], !Not [!Equals [!Ref SummarizationLLMThirdPartyApiKey, undefined]]]
+  ShouldTestBedrockModelId: !Or [!Equals [!Ref CallSummarization, 'BEDROCK'], !Equals [!Ref GenAIQuery, 'BEDROCK'],]
+  ShouldTestGenAIQueryBedrockModelId: !Equals [!Ref GenAIQuery, 'BEDROCK']
+  ShouldTestSummarizationBedrockModelId: !Equals [!Ref CallSummarization, 'BEDROCK']
+
 
 Resources:
   ########################################################
@@ -738,7 +742,153 @@ Resources:
             Facetable: true
           Type: 'STRING_LIST_VALUE'
 
+  ########################################################
+  # If Bedrock Models are selected, verify that Bedrock 
+  # is avialble in the region, and that models are enabled
+  ########################################################
 
+  TestBedrockModelFunctionRole:
+    Type: AWS::IAM::Role
+    Condition: ShouldTestBedrockModelId
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "bedrock:InvokeModel"
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:bedrock:*::foundation-model/*"
+                  - !Sub "arn:${AWS::Partition}:bedrock:*:${AWS::AccountId}:custom-model/*"
+          PolicyName: BedrockPolicy
+
+  TestBedrockModelFunction:
+    Type: AWS::Lambda::Function
+    Condition: ShouldTestBedrockModelId
+    Properties:
+      Handler: index.lambda_handler
+      Role: !GetAtt 'TestBedrockModelFunctionRole.Arn'
+      Runtime: python3.11
+      Timeout: 60
+      MemorySize: 128
+      Code: 
+        ZipFile: !Sub |
+          import cfnresponse
+          import json
+          import subprocess
+          import os
+          import sys
+          print("install latest boto3 to get bedrock service support")
+          subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--target', '/tmp', 'boto3'])
+          sys.path.insert(0,'/tmp')
+          import boto3
+
+          # Defaults
+          AWS_REGION = os.environ["AWS_REGION_OVERRIDE"] if "AWS_REGION_OVERRIDE" in os.environ else os.environ["AWS_REGION"]
+          ENDPOINT_URL = os.environ.get("ENDPOINT_URL", f'https://bedrock-runtime.{AWS_REGION}.amazonaws.com')
+          DEFAULT_MAX_TOKENS = 128
+
+          def get_request_body(modelId, parameters, prompt):
+              provider = modelId.split(".")[0]
+              request_body = None
+              if provider == "anthropic":
+                  request_body = {
+                      "prompt": prompt,
+                      "max_tokens_to_sample": DEFAULT_MAX_TOKENS
+                  } 
+                  request_body.update(parameters)
+              elif provider == "ai21":
+                  request_body = {
+                      "prompt": prompt,
+                      "maxTokens": DEFAULT_MAX_TOKENS
+                  }
+                  request_body.update(parameters)
+              elif provider == "amazon":
+                  textGenerationConfig = {
+                      "maxTokenCount": DEFAULT_MAX_TOKENS
+                  }
+                  textGenerationConfig.update(parameters)
+                  request_body = {
+                      "inputText": prompt,
+                      "textGenerationConfig": textGenerationConfig
+                  }
+              else:
+                  raise Exception("Unsupported provider: ", provider)
+              return request_body
+
+          def get_generate_text(modelId, response):
+              provider = modelId.split(".")[0]
+              generated_text = None
+              if provider == "anthropic":
+                  response_body = json.loads(response.get("body").read().decode())
+                  generated_text = response_body.get("completion")
+              elif provider == "ai21":
+                  response_body = json.loads(response.get("body").read())
+                  generated_text = response_body.get("completions")[0].get("data").get("text")
+              elif provider == "amazon":
+                  response_body = json.loads(response.get("body").read())
+                  generated_text = response_body.get("results")[0].get("outputText")
+              else:
+                  raise Exception("Unsupported provider: ", provider)
+              return generated_text
+
+          def call_llm(parameters, prompt):
+              modelId = parameters.pop("modelId")
+              body = get_request_body(modelId, parameters, prompt)
+              print("ModelId", modelId, "-  Body: ", body)
+              client = boto3.client(service_name='bedrock-runtime', region_name=AWS_REGION, endpoint_url=ENDPOINT_URL)
+              response = client.invoke_model(body=json.dumps(body), modelId=modelId, accept='application/json', contentType='application/json')
+              generated_text = get_generate_text(modelId, response)
+              return generated_text
+
+          def lambda_handler(event, context):
+              print("Event: ", json.dumps(event))
+              global client
+              status = cfnresponse.SUCCESS
+              responseData = {}
+              reason = "Success"
+              modelId = ""
+              if event['RequestType'] != 'Delete':
+                  prompt = "\n\nHuman: Why is the sky blue?\n\nAssistant:"
+                  try:
+                      # Test LLMModel
+                      llmModelId = event['ResourceProperties'].get('LLMModelId', '')
+                      modelId = llmModelId
+                      parameters = {
+                          "modelId": modelId,
+                          "temperature": 0
+                      }
+                      print(f"Testing {modelId}")
+                      call_llm(parameters, prompt)            
+                  except Exception as e:
+                      status = cfnresponse.FAILED
+                      reason = f"Exception thrown testing ModelId='{modelId}'. Check that Amazon Bedrock is available in your region, and that model is activated in your Amazon Bedrock account - {e}"
+              print(f"Status: {status}, Reason: {reason}")        
+              cfnresponse.send(event, context, status, responseData, reason=reason)
+
+  TestGenAIQueryBedrockModelId:
+    Type: Custom::TestGenAIQueryBedrockModelId
+    Condition: ShouldTestGenAIQueryBedrockModelId
+    Properties:
+      ServiceToken: !GetAtt TestBedrockModelFunction.Arn
+      LLMModelId: !Ref GenAIQueryBedrockModelId
+
+  TestSummarizationBedrockModelId:
+    Type: Custom::SummarizationBedrockModelId
+    Condition: ShouldTestSummarizationBedrockModelId
+    Properties:
+      ServiceToken: !GetAtt TestBedrockModelFunction.Arn
+      LLMModelId: !Ref SummarizationBedrockModelId
   
   ########################################################
   # SSM Stack


### PR DESCRIPTION
Test that Bedrock service and selected models are available in account during stack create/update to avoid downstream failures

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
