### PR TITLE
Feature/call summary refresh

### DIFF
--- a/pca-main-nokendra.template
+++ b/pca-main-nokendra.template
@@ -900,7 +900,7 @@ Resources:
         GenAIQueryType: !Ref GenAIQuery
         GenAIQueryBedrockModelId: !Ref GenAIQueryBedrockModelId
         FetchTranscriptArn: !GetAtt PCAServer.Outputs.FetchTranscriptArn
-	SummarizerArn: !GetAtt PCAServer.Outputs.SummarizerArn
+        SummarizerArn: !GetAtt PCAServer.Outputs.SummarizerArn
         LLMThirdPartyApiKey: !If 
           - ShouldDeployLLMThirdPartyApiKey
           - !Ref LLMThirdPartyApiKeySecret

--- a/pca-main-nokendra.template
+++ b/pca-main-nokendra.template
@@ -900,6 +900,7 @@ Resources:
         GenAIQueryType: !Ref GenAIQuery
         GenAIQueryBedrockModelId: !Ref GenAIQueryBedrockModelId
         FetchTranscriptArn: !GetAtt PCAServer.Outputs.FetchTranscriptArn
+	SummarizerArn: !GetAtt PCAServer.Outputs.SummarizerArn
         LLMThirdPartyApiKey: !If 
           - ShouldDeployLLMThirdPartyApiKey
           - !Ref LLMThirdPartyApiKeySecret

--- a/pca-main.template
+++ b/pca-main.template
@@ -1032,7 +1032,7 @@ Resources:
         GenAIQueryType: !Ref GenAIQuery
         GenAIQueryBedrockModelId: !Ref GenAIQueryBedrockModelId
         FetchTranscriptArn: !GetAtt PCAServer.Outputs.FetchTranscriptArn
-	SummarizerArn: !GetAtt PCAServer.Outputs.SummarizerArn
+        SummarizerArn: !GetAtt PCAServer.Outputs.SummarizerArn
         LLMThirdPartyApiKey: !If 
           - ShouldDeployLLMThirdPartyApiKey
           - !Ref LLMThirdPartyApiKeySecret

--- a/pca-main.template
+++ b/pca-main.template
@@ -1032,6 +1032,7 @@ Resources:
         GenAIQueryType: !Ref GenAIQuery
         GenAIQueryBedrockModelId: !Ref GenAIQueryBedrockModelId
         FetchTranscriptArn: !GetAtt PCAServer.Outputs.FetchTranscriptArn
+	SummarizerArn: !GetAtt PCAServer.Outputs.SummarizerArn
         LLMThirdPartyApiKey: !If 
           - ShouldDeployLLMThirdPartyApiKey
           - !Ref LLMThirdPartyApiKeySecret

--- a/pca-server/cfn/lib/pca.template
+++ b/pca-server/cfn/lib/pca.template
@@ -432,3 +432,6 @@ Outputs:
 
   FetchTranscriptArn:
     Value: !GetAtt SFFetchTranscript.Arn
+
+  SummarizerArn:
+    Value: !GetAtt SFSummarize.Arn

--- a/pca-server/cfn/pca-server.template
+++ b/pca-server/cfn/pca-server.template
@@ -160,6 +160,9 @@ Outputs:
   FetchTranscriptArn:
     Value: !GetAtt PCA.Outputs.FetchTranscriptArn
 
+  SummarizerArn:
+    Value: !GetAtt PCA.Outputs.SummarizerArn
+
   RolesForKMSKey:
     Value: !Join
       - ', '

--- a/pca-server/src/pca/pca-aws-sf-summarize.py
+++ b/pca-server/src/pca/pca-aws-sf-summarize.py
@@ -290,6 +290,7 @@ def lambda_handler(event, context):
         pca_results.analytics.summary = summary_json
         print("Summary JSON: " + summary)
     else:
+        pca_results.analytics.summary = {}
         pca_results.analytics.summary['Summary'] = summary
         print("Summary: " + summary)
     

--- a/pca-ui/cfn/lib/api.template
+++ b/pca-ui/cfn/lib/api.template
@@ -43,6 +43,11 @@ Parameters:
     AllowedPattern: '^(|arn:aws:lambda:.*)$'
     Description: Arn to use for the GenAIQuery to fetch transcript
 
+  SummarizerArn:
+    Type: String
+    AllowedPattern: '^(|arn:aws:lambda:.*)$'
+    Description: Arn to use to refresh the GenAI Summaries
+
   LLMThirdPartyApiKey:
     Type: String
     Description: >
@@ -297,6 +302,37 @@ Resources:
                   - 'secretsmanager:ListSecretVersionIds'
                 Resource: !Ref LLMThirdPartyApiKey
               - !Ref "AWS::NoValue"
+      Runtime: python3.11
+
+  GenAIRefreshSummaryFunction:
+    Type: "AWS::Serverless::Function"
+    Properties:
+      CodeUri:  ../../src/genai
+      Handler: refresh_summary.lambda_handler
+      Timeout: 900
+      Layers:
+        - !Ref PyUtilsLayerArn
+        - !If
+          - ShouldAddBoto3Layer
+          - !Ref Boto3LayerArn
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          SUMMARIZER_ARN: !Ref SummarizerArn
+      Events:
+        APIEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref Api
+            Method: GET
+            Path: /genai/refreshsummary
+      Policies:
+        - Statement:
+          - Sid: InvokeGetSummary
+            Effect: Allow
+            Action:
+              - lambda:InvokeFunction
+            Resource: !Ref SummarizerArn
       Runtime: python3.11
 
 Outputs:

--- a/pca-ui/cfn/lib/deploy.template
+++ b/pca-ui/cfn/lib/deploy.template
@@ -6,6 +6,9 @@ Parameters:
   Bucket:
     Type: String
 
+  AudioBucket:
+    Type: String
+
   AuthUri:
     Type: String
 
@@ -98,6 +101,7 @@ Resources:
     DependsOn: Deploy
     Properties:
       Bucket: !Ref Bucket
+      AudioBucket: !Ref AudioBucket
       ServiceToken: !GetAtt ConfigureFunction.Arn
       AuthUri: !Ref AuthUri
       AuthClientId: !Ref AuthClientId

--- a/pca-ui/cfn/pca-ui.template
+++ b/pca-ui/cfn/pca-ui.template
@@ -70,6 +70,11 @@ Parameters:
     AllowedPattern: '^(|arn:aws:lambda:.*)$'
     Description: Arn to use for the GenAIQuery to fetch transcript
 
+  SummarizerArn:
+    Type: String
+    AllowedPattern: '^(|arn:aws:lambda:.*)$'
+    Description: Arn to use to refresh the GenAI Summaries
+
   Boto3LayerArn:
     Default: ''
     Type: String
@@ -137,6 +142,7 @@ Resources:
         GenAIQueryBedrockModelId: !Ref GenAIQueryBedrockModelId
         LLMThirdPartyApiKey: !Ref LLMThirdPartyApiKey
         FetchTranscriptArn: !Ref FetchTranscriptArn
+        SummarizerArn: !Ref SummarizerArn
         Boto3LayerArn: !Ref Boto3LayerArn
         PyUtilsLayerArn: !Ref PyUtilsLayerArn
 
@@ -146,6 +152,7 @@ Resources:
       TemplateURL: lib/deploy.template
       Parameters:
         Bucket: !GetAtt Web.Outputs.Bucket
+        AudioBucket: !Ref AudioBucket
         AuthUri: !GetAtt Cognito.Outputs.BaseUri
         AuthClientId: !GetAtt Cognito.Outputs.UserPoolClientId
         ApiUri: !GetAtt Api.Outputs.Uri

--- a/pca-ui/src/genai/refresh_summary.py
+++ b/pca-ui/src/genai/refresh_summary.py
@@ -1,0 +1,53 @@
+"""
+This python function is part of the main processing workflow.
+It invokes the call summary function to re-trigger the summarization process
+when a user chooses to refresh the call Generative AI Insights after they made
+updates to the LLMPromptSummaryTemplate.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+import boto3
+import os
+import json
+import urllib.parse
+
+SUMMARIZER_ARN = os.getenv('SUMMARIZER_ARN','')
+
+lambda_client = boto3.client('lambda')
+
+def lambda_handler(event, context):
+    """
+    Lambda function entrypoint
+    """
+    
+    print(event)
+    queryStringParameters = event['queryStringParameters']
+
+    # Access the values of the query string parameters
+    filename = urllib.parse.unquote(queryStringParameters['filename'])
+
+    payload = {
+        'interimResultsFile': filename,
+    }
+    print(payload)
+    lambda_client.invoke(
+        FunctionName=SUMMARIZER_ARN,
+        InvocationType=' Event',
+        Payload=json.dumps(payload)
+    )
+
+    response = {
+        "statusCode": 200,
+        "headers": {
+            "Access-Control-Allow-Headers":
+            "Content-Type,X-Amz-Date,Authorization,X-Api-Key",
+            "Content-Type": "application/json",
+            "access-control-allow-origin": "*",
+            "access-control-allow-methods": "OPTIONS,GET"
+        },
+        "body": json.dumps({
+            "response": "Success!!!"
+        })
+    }
+    return response

--- a/pca-ui/src/genai/refresh_summary.py
+++ b/pca-ui/src/genai/refresh_summary.py
@@ -33,7 +33,7 @@ def lambda_handler(event, context):
     print(payload)
     lambda_client.invoke(
         FunctionName=SUMMARIZER_ARN,
-        InvocationType=' Event',
+        InvocationType='RequestResponse',
         Payload=json.dumps(payload)
     )
 

--- a/pca-ui/src/www/src/api/api.js
+++ b/pca-ui/src/www/src/api/api.js
@@ -89,3 +89,9 @@ export async function genaiquery(filename, query) {
     "query": query
   } );
 }
+
+export async function genairefresh(filename) {
+  return getRequest("genai/refreshsummary", {
+    "filename": filename,
+  } );
+}

--- a/pca-ui/src/www/src/routes/Dashboard/index.js
+++ b/pca-ui/src/www/src/routes/Dashboard/index.js
@@ -253,14 +253,12 @@ function Dashboard({ setAlert }) {
   const SummaryRefresh = () => {
     const [disabled, setDisabled] = useState(false);
 
-    const onSubmit = (e) => {
+    const onSubmit = async (e) => {
       e.preventDefault();
       setDisabled(true);
-      genairefresh(key);
-      setTimeout(() => {
-        setDisabled(false);
-        mutate(`/get/${key}`);
-      }, 15000)
+      await genairefresh(key);
+      setDisabled(false);
+      mutate(`/get/${key}`);
 
       return true;
     }

--- a/pca-ui/src/www/src/routes/Dashboard/index.js
+++ b/pca-ui/src/www/src/routes/Dashboard/index.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, Fragment, useRef } from "react";
 import { useParams } from "react-router";
 import useSWR, { useSWRConfig } from "swr";
-import { get,genaiquery, swap } from "../../api/api";
+import { get, genaiquery, swap, genairefresh } from "../../api/api";
 import { Formatter } from "../../format";
 import { TranscriptSegment } from "./TranscriptSegment";
 import { Entities } from "./Entities";
@@ -59,7 +59,7 @@ function Dashboard({ setAlert }) {
   const transcriptElem = useRef();
 
   const { data, error } = useSWR(`/get/${key}`, () => get(key), {
-    revalidateIfStale: false,
+    revalidateIfStale: true,
     revalidateOnFocus: false,
     revalidateOnReconnect: false
   });
@@ -249,6 +249,31 @@ function Dashboard({ setAlert }) {
     });
     setGenAiQueryStatus(false);
   }
+
+  const SummaryRefresh = () => {
+    const [disabled, setDisabled] = useState(false);
+
+    const onSubmit = (e) => {
+      e.preventDefault();
+      setDisabled(true);
+      genairefresh(key);
+      setTimeout(() => {
+        setDisabled(false);
+        mutate(`/get/${key}`);
+      }, 15000)
+
+      return true;
+    }
+
+    return (
+        <form onSubmit={onSubmit}>
+          <Grid gridDefinition={[{ colspan: { default: 12, xxs: 9 } }, { default: 12, xxs: 3 }]}>
+            {disabled ? <Spinner size="big" variant="disabled"/> : <Button disabled={disabled} iconName="refresh" variant="normal" ariaLabel="refresh">
+            </Button>}
+          </Grid>
+        </form>
+    );
+  };
 
   const swapAgent = async () => {
     try {
@@ -654,10 +679,17 @@ function Dashboard({ setAlert }) {
         <Container
           fitHeight={true}
           header={
-            <Header variant="h2">
+            <Header variant="h2"
+              actions = {
+                <SpaceBetween direction="horizontal" size="xs">
+                  <SummaryRefresh/>
+                </SpaceBetween>
+              }
+            >
               Generative AI Insights
             </Header>
           }
+
         >
           <SpaceBetween size="m">
             {genAiSummary.length > 0 ? genAiSummary.map((entry, i) => (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added a refresh to Generative AI Insights component of the PCA UI to get updated summaries after a user updates the LLMPromptSummaryTemplate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
