### PR TITLE
Aligning `SummarizationBedrockModelId` Parameter Across CloudFormation Templates

### DIFF
--- a/pca-server/cfn/pca-server.template
+++ b/pca-server/cfn/pca-server.template
@@ -24,15 +24,13 @@ Parameters:
   
   SummarizationBedrockModelId:
     Type: String
-    Default: anthropic.claude-v2
+    Default: anthropic.claude-instant-v1
     AllowedValues:
-      - amazon.titan-tg1-large
-      #- ai21.j2-grande-instruct
-      #- ai21.j2-jumbo-instruct
+      - amazon.titan-text-express-v1
       - anthropic.claude-v1
       - anthropic.claude-instant-v1
       - anthropic.claude-v2
-    Description: (Optional) If 'CallSummarization' is BEDROCK, which Bedrock model to use. (Bedrock preview access only)
+    Description: (Optional) If 'CallSummarization' is BEDROCK, which Bedrock model to use.
 
   SummarizationSageMakerInitialInstanceCount:
     Type: Number

--- a/pca-ui/cfn/pca-ui.template
+++ b/pca-ui/cfn/pca-ui.template
@@ -55,13 +55,13 @@ Parameters:
   
   GenAIQueryBedrockModelId:
     Type: String
-    Default: anthropic.claude-v2
+    Default: anthropic.claude-instant-v1
     AllowedValues:
-      - amazon.titan-tg1-large
+      - amazon.titan-text-express-v1
       - anthropic.claude-v1
       - anthropic.claude-instant-v1
       - anthropic.claude-v2
-    Description: (Optional) If 'GenAIQuery' is BEDROCK, which Bedrock model to use. (Bedrock preview access only)
+    Description: (Optional) If 'GenAIQuery' is BEDROCK, which Bedrock model to use.
 
   LLMThirdPartyApiKey:
     Type: String


### PR DESCRIPTION
### Pull Request Overview
This pull request addresses the issue outlined in [Issue #217](https://github.com/aws-samples/amazon-transcribe-post-call-analytics/issues/217). The main goal is to harmonize the `SummarizationBedrockModelId` parameter values across different CloudFormation templates used in the Amazon Transcribe Post-Call Analytics solution.

### Changes Made
Modified the `SummarizationBedrockModelId` parameter in the `pca-server` template (located [here](https://github.com/aws-samples/amazon-transcribe-post-call-analytics/blob/develop/pca-server/cfn/pca-server.template)).
Updated the `SummarizationBedrockModelId` parameter in the `pca-ui` template (available [here](https://github.com/aws-samples/amazon-transcribe-post-call-analytics/blob/develop/pca-ui/cfn/pca-ui.template)).
Ensured that both templates now align with the `SummarizationBedrockModelId` parameter as defined in the `pca-main` template ([link to template](https://github.com/aws-samples/amazon-transcribe-post-call-analytics/blob/develop/pca-main.template)).
### Rationale
The inconsistency in the `SummarizationBedrockModelId` parameter across these templates was causing deployment failures, as reported by users. By aligning these parameters, this pull request aims to resolve deployment issues of the Amazon Transcribe Post-Call Analytics CloudFormation stack.

### Request for Review
I kindly request a review of these changes to ensure they align with the project's standards and effectively resolve the issue. Feedback or suggestions for further improvements are greatly welcomed.
Thank you for considering this pull request.