### PR TITLE
Fix isprod condition checked value for PROD string

### DIFF
--- a/pca-ui/cfn/lib/cognito.template
+++ b/pca-ui/cfn/lib/cognito.template
@@ -20,7 +20,7 @@ Parameters:
     Type: String
 
 Conditions:
-  IsProd: !Equals [!Ref Environment, true]
+  IsProd: !Equals [!Ref Environment, PROD]
 
 Resources:
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The condition check for a production environment was not formed correctly. It compared $Environment against the string/bool of `true`. The [possible values for $Environment are `DEV`, `TEST`, `PROD`](https://github.com/aws-samples/amazon-transcribe-post-call-analytics/blob/15220544397f36c64aed9718776f6a3538f3c84a/pca-main.template#L327). This checks checks for the string `PROD`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
