### PR TITLE
Changed default email in CLI output of publish.sh to break the valida…

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -137,7 +137,7 @@ aws cloudformation validate-template --template-url $template > /dev/null || exi
 echo "Outputs"
 echo Template URL: $template
 echo CF Launch URL: https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stacks/create/review?templateURL=${template}\&stackName=PCA
-echo CLI Deploy: aws cloudformation deploy --template-file `pwd`/build/packaged.template --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --stack-name PCA --parameter-overrides AdminEmail=johndoe@example.com
+echo CLI Deploy: aws cloudformation deploy --template-file `pwd`/build/packaged.template --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --stack-name PCA --parameter-overrides AdminEmail=YOUR_EMAIL
 
 echo Done
 exit 0


### PR DESCRIPTION
Changing the email suggestion in the CLI produced by the publish.sh script to prevent accidentally using the fake one

See script output and screenshot for testing evidence

====================
      Outputs       
====================
MSINDEXER Template URL - https://johans-generic-aws-dev-bucket.s3.us-east-1.amazonaws.com/artifacts/0.7.10/mediasearch/msindexer.yaml

MSINDEXER CF Launch URL - https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://johans-generic-aws-dev-bucket.s3.us-east-1.amazonaws.com/artifacts/0.7.10/mediasearch/msindexer.yaml&stackName=MediaSearch-MSINDEXER

MSFINDER Template URL - https://johans-generic-aws-dev-bucket.s3.us-east-1.amazonaws.com/artifacts/0.7.10/mediasearch/msfinder.yaml

MSFINDER CF Launch URL - https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://johans-generic-aws-dev-bucket.s3.us-east-1.amazonaws.com/artifacts/0.7.10/mediasearch/msfinder.yaml&stackName=MediaSearch-MSFINDER

Done
~/git/amazon-transcribe-post-call-analytics
download: s3://johans-generic-aws-dev-bucket/artifacts/0.7.10/mediasearch/msfinder.yaml to build/pca-mediasearch-finder.yaml
Packaging Cfn artifacts
Uploading to artifacts/0.7.10/f361ee47fecffae10304d0333e2db266.template  2403 / 2403.0  (100.00%)%)
Successfully packaged artifacts and wrote output template to file build/packaged.template.
Execute the following command to deploy the packaged template
aws cloudformation deploy --template-file /home/ec2-user/git/amazon-transcribe-post-call-analytics/build/packaged.template --stack-name <YOUR STACK NAME>
upload: build/packaged.template to s3://johans-generic-aws-dev-bucket/artifacts/pca-main.yaml
Validating Cfn artifacts
Outputs
Template URL: https://s3.us-east-1.amazonaws.com/johans-generic-aws-dev-bucket/artifacts/pca-main.yaml
CF Launch URL: https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.us-east-1.amazonaws.com/johans-generic-aws-dev-bucket/artifacts/pca-main.yaml&stackName=PCA
CLI Deploy: aws cloudformation deploy --template-file /home/ec2-user/git/amazon-transcribe-post-call-analytics/build/packaged.template --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --stack-name PCA --parameter-overrides AdminEmail=YOUR_EMAIL
Done
[ec2-user@ip-172-31-88-198 amazon-transcribe-post-call-analytics]$ aws cloudformation deploy --template-file /home/ec2-user/git/amazon-transcribe-post-call-analytics/build/packaged.template --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --stack-name PCA --parameter-overrides AdminEmail=**YOUR_EMAIL

An error occurred (ValidationError) when calling the CreateChangeSet operation: Parameter AdminEmail failed to satisfy constraint: Must be valid email address eg. johndoe@example.com**

<img width="1870" alt="email_capture" src="https://github.com/user-attachments/assets/1d57ebf8-451f-4317-aaca-357781ec90d2">

