### PR TITLE
Add option to disbale model checks and self signup to the web UI

### DIFF
--- a/pca-main-nokendra.template
+++ b/pca-main-nokendra.template
@@ -22,7 +22,8 @@ Parameters:
     Default: ""
     Description: >-
       Email address domain (example.com) or comma separated list of email domains  (example1.com,
-      example2.com) allowed to signin and signup using the web UI.
+      example2.com) allowed to signin and signup using the web UI. To allow signup from any domain, 
+      enter *.
       If left empty, signup via the web UI is disabled and users will have to be created
       using
       Cognito.

--- a/pca-main-nokendra.template
+++ b/pca-main-nokendra.template
@@ -586,17 +586,23 @@ Conditions:
     !Equals [!Ref GenAIQuery, 'BEDROCK'],
   ]
   ShouldDeployLLMThirdPartyApiKey: !And [!Not [!Equals [!Ref SummarizationLLMThirdPartyApiKey, '']], !Not [!Equals [!Ref SummarizationLLMThirdPartyApiKey, undefined]]]
-  ShouldTestBedrockModelId: !And [!Or [
-    !Equals [!Ref CallSummarization, 'BEDROCK'], 
-    !Equals [!Ref CallSummarization, "BEDROCK+TCA"],
-    !Equals [!Ref GenAIQuery, 'BEDROCK'],], !Equals [!Ref TestBedrockModelId, 'true']]
+  ShouldTestBedrockModelId: !And [
+    !Or [
+      !Equals [!Ref CallSummarization, 'BEDROCK'], 
+      !Equals [!Ref CallSummarization, "BEDROCK+TCA"],
+      !Equals [!Ref GenAIQuery, 'BEDROCK'],
+    ], 
+    !Equals [!Ref TestBedrockModelId, 'true']
+  ]
   ShouldTestGenAIQueryBedrockModelId: !And [
     !Equals [!Ref GenAIQuery, 'BEDROCK'], 
     !Equals [!Ref TestBedrockModelId, 'true']
   ]
-  ShouldTestSummarizationBedrockModelId: !And [!Or [
-    !Equals [!Ref CallSummarization, 'BEDROCK'],
-    !Equals [!Ref CallSummarization, "BEDROCK+TCA"],], 
+  ShouldTestSummarizationBedrockModelId: !And [
+    !Or [
+      !Equals [!Ref CallSummarization, 'BEDROCK'],
+      !Equals [!Ref CallSummarization, "BEDROCK+TCA"],
+    ], 
     !Equals [!Ref TestBedrockModelId, 'true']
   ]
 

--- a/pca-main-nokendra.template
+++ b/pca-main-nokendra.template
@@ -17,6 +17,17 @@ Parameters:
       AllowedPattern: ".+\\@.+\\..+"
       ConstraintDescription: Must be valid email address eg. johndoe@example.com
 
+  AllowedSignUpEmailDomain:
+    Type: String
+    Default: ""
+    Description: >-
+      Email address domain (example.com) or comma separated list of email domains  (example1.com,
+      example2.com) allowed to signin and signup using the web UI.
+      If left empty, signup via the web UI is disabled and users will have to be created
+      using
+      Cognito.
+    AllowedPattern: '^(\*||([\w-]+\.)+[\w-]{2,6}(, *([\w-]+\.)+[\w-]{2,6})*)$'
+
   BulkUploadBucketName:
     Type: String
     Default: ""
@@ -415,6 +426,15 @@ Parameters:
       - anthropic.claude-v2
     Description: (Optional) If 'CallSummarization' is BEDROCK, which Bedrock model to use.
 
+  TestBedrockModelId:
+    Type: String
+    Default: true
+    AllowedValues:
+        - true
+        - false
+    Description: >
+      Set to false to disable checking if the Bedrock models are enabled. 
+
   SummarizationSageMakerInitialInstanceCount:
     Type: Number
     MinValue: 0
@@ -444,6 +464,7 @@ Metadata:
               Parameters:
                   - AdminUsername
                   - AdminEmail
+                  - AllowedSignUpEmailDomain
             - Label:
                 default: Sample Data
               Parameters:
@@ -545,6 +566,7 @@ Metadata:
                 - Environment
                 - StepFunctionName
                 - ffmpegDownloadUrl 
+                - TestBedrockModelId
 
 Conditions:
   ShouldCreateBulkUploadBucket: !Equals [!Ref BulkUploadBucketName, '']
@@ -563,14 +585,18 @@ Conditions:
     !Equals [!Ref GenAIQuery, 'BEDROCK'],
   ]
   ShouldDeployLLMThirdPartyApiKey: !And [!Not [!Equals [!Ref SummarizationLLMThirdPartyApiKey, '']], !Not [!Equals [!Ref SummarizationLLMThirdPartyApiKey, undefined]]]
-  ShouldTestBedrockModelId: !Or [
+  ShouldTestBedrockModelId: !And [!Or [
     !Equals [!Ref CallSummarization, 'BEDROCK'], 
     !Equals [!Ref CallSummarization, "BEDROCK+TCA"],
-    !Equals [!Ref GenAIQuery, 'BEDROCK'],]
-  ShouldTestGenAIQueryBedrockModelId: !Equals [!Ref GenAIQuery, 'BEDROCK']
-  ShouldTestSummarizationBedrockModelId: !Or [
+    !Equals [!Ref GenAIQuery, 'BEDROCK'],], !Equals [!Ref TestBedrockModelId, 'true']]
+  ShouldTestGenAIQueryBedrockModelId: !And [
+    !Equals [!Ref GenAIQuery, 'BEDROCK'], 
+    !Equals [!Ref TestBedrockModelId, 'true']
+  ]
+  ShouldTestSummarizationBedrockModelId: !And [!Or [
     !Equals [!Ref CallSummarization, 'BEDROCK'],
-    !Equals [!Ref CallSummarization, "BEDROCK+TCA"],
+    !Equals [!Ref CallSummarization, "BEDROCK+TCA"],], 
+    !Equals [!Ref TestBedrockModelId, 'true']
   ]
 
 Resources:
@@ -935,6 +961,7 @@ Resources:
       Parameters:
         AdminUsername: !Ref AdminUsername
         AdminEmail: !Ref AdminEmail
+        AllowedSignUpEmailDomain: !Ref AllowedSignUpEmailDomain
         MainStackName: !Ref AWS::StackName
         AudioBucket:
           !If

--- a/pca-main.template
+++ b/pca-main.template
@@ -22,7 +22,8 @@ Parameters:
     Default: ""
     Description: >-
       Email address domain (example.com) or comma separated list of email domains  (example1.com,
-      example2.com) allowed to signin and signup using the web UI.
+      example2.com) allowed to signin and signup using the web UI. To allow signup from any domain, 
+      enter *.
       If left empty, signup via the web UI is disabled and users will have to be created
       using
       Cognito.

--- a/pca-main.template
+++ b/pca-main.template
@@ -627,17 +627,23 @@ Conditions:
     !Equals [!Ref GenAIQuery, 'BEDROCK'],
   ]
   ShouldDeployLLMThirdPartyApiKey: !And [!Not [!Equals [!Ref SummarizationLLMThirdPartyApiKey, '']], !Not [!Equals [!Ref SummarizationLLMThirdPartyApiKey, undefined]]]
-  ShouldTestBedrockModelId: !And [!Or [
-    !Equals [!Ref CallSummarization, 'BEDROCK'], 
-    !Equals [!Ref CallSummarization, "BEDROCK+TCA"],
-    !Equals [!Ref GenAIQuery, 'BEDROCK'],], !Equals [!Ref TestBedrockModelId, 'true']]
+  ShouldTestBedrockModelId: !And [
+    !Or [
+      !Equals [!Ref CallSummarization, 'BEDROCK'], 
+      !Equals [!Ref CallSummarization, "BEDROCK+TCA"],
+      !Equals [!Ref GenAIQuery, 'BEDROCK'],
+    ], 
+    !Equals [!Ref TestBedrockModelId, 'true']
+  ]
   ShouldTestGenAIQueryBedrockModelId: !And [
     !Equals [!Ref GenAIQuery, 'BEDROCK'], 
     !Equals [!Ref TestBedrockModelId, 'true']
   ]
-  ShouldTestSummarizationBedrockModelId: !And [!Or [
-    !Equals [!Ref CallSummarization, 'BEDROCK'],
-    !Equals [!Ref CallSummarization, "BEDROCK+TCA"],], 
+  ShouldTestSummarizationBedrockModelId: !And [
+    !Or [
+      !Equals [!Ref CallSummarization, 'BEDROCK'],
+      !Equals [!Ref CallSummarization, "BEDROCK+TCA"],
+    ], 
     !Equals [!Ref TestBedrockModelId, 'true']
   ]
 

--- a/pca-main.template
+++ b/pca-main.template
@@ -17,6 +17,17 @@ Parameters:
       AllowedPattern: ".+\\@.+\\..+"
       ConstraintDescription: Must be valid email address eg. johndoe@example.com
 
+  AllowedSignUpEmailDomain:
+    Type: String
+    Default: ""
+    Description: >-
+      Email address domain (example.com) or comma separated list of email domains  (example1.com,
+      example2.com) allowed to signin and signup using the web UI.
+      If left empty, signup via the web UI is disabled and users will have to be created
+      using
+      Cognito.
+    AllowedPattern: '^(\*||([\w-]+\.)+[\w-]{2,6}(, *([\w-]+\.)+[\w-]{2,6})*)$'
+
   BulkUploadBucketName:
     Type: String
     Default: ""
@@ -456,6 +467,15 @@ Parameters:
       - anthropic.claude-v2
     Description: (Optional) If 'CallSummarization' is BEDROCK, which Bedrock model to use. 
 
+  TestBedrockModelId:
+    Type: String
+    Default: true
+    AllowedValues:
+        - true
+        - false
+    Description: >
+      Set to false to disable checking if the Bedrock models are enabled. 
+
   SummarizationSageMakerInitialInstanceCount:
     Type: Number
     MinValue: 0
@@ -485,6 +505,7 @@ Metadata:
               Parameters:
                   - AdminUsername
                   - AdminEmail
+                  - AllowedSignUpEmailDomain
             - Label:
                 default: Sample Data
               Parameters:
@@ -586,6 +607,7 @@ Metadata:
                 - Environment
                 - StepFunctionName
                 - ffmpegDownloadUrl 
+                - TestBedrockModelId
 
 Conditions:
   ShouldCreateBulkUploadBucket: !Equals [!Ref BulkUploadBucketName, '']
@@ -604,14 +626,18 @@ Conditions:
     !Equals [!Ref GenAIQuery, 'BEDROCK'],
   ]
   ShouldDeployLLMThirdPartyApiKey: !And [!Not [!Equals [!Ref SummarizationLLMThirdPartyApiKey, '']], !Not [!Equals [!Ref SummarizationLLMThirdPartyApiKey, undefined]]]
-  ShouldTestBedrockModelId: !Or [
+  ShouldTestBedrockModelId: !And [!Or [
     !Equals [!Ref CallSummarization, 'BEDROCK'], 
     !Equals [!Ref CallSummarization, "BEDROCK+TCA"],
-    !Equals [!Ref GenAIQuery, 'BEDROCK'],]
-  ShouldTestGenAIQueryBedrockModelId: !Equals [!Ref GenAIQuery, 'BEDROCK']
-  ShouldTestSummarizationBedrockModelId: !Or [
+    !Equals [!Ref GenAIQuery, 'BEDROCK'],], !Equals [!Ref TestBedrockModelId, 'true']]
+  ShouldTestGenAIQueryBedrockModelId: !And [
+    !Equals [!Ref GenAIQuery, 'BEDROCK'], 
+    !Equals [!Ref TestBedrockModelId, 'true']
+  ]
+  ShouldTestSummarizationBedrockModelId: !And [!Or [
     !Equals [!Ref CallSummarization, 'BEDROCK'],
-    !Equals [!Ref CallSummarization, "BEDROCK+TCA"],
+    !Equals [!Ref CallSummarization, "BEDROCK+TCA"],], 
+    !Equals [!Ref TestBedrockModelId, 'true']
   ]
 
 Rules:
@@ -1119,6 +1145,7 @@ Resources:
       Parameters:
         AdminUsername: !Ref AdminUsername
         AdminEmail: !Ref AdminEmail
+        AllowedSignUpEmailDomain: !Ref AllowedSignUpEmailDomain
         MainStackName: !Ref AWS::StackName
         AudioBucket:
           !If

--- a/pca-ui/cfn/lib/cognito.template
+++ b/pca-ui/cfn/lib/cognito.template
@@ -1,4 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
 
 Description: Amazon Transcribe Post Call Analytics - PCA UI - Cognito
 
@@ -10,6 +11,17 @@ Parameters:
   AdminEmail:
       Type: String
 
+  AllowedSignUpEmailDomain:
+    Type: String
+    Default: ""
+    Description: >-
+      Email address domain (example.com) or comma separated list of email domains  (example1.com,
+      example2.com) allowed to signin and signup using the web UI.
+      If left empty, signup via the web UI is disabled and users will have to be created
+      using
+      Cognito.
+    AllowedPattern: '^(\*||([\w-]+\.)+[\w-]{2,6}(, *([\w-]+\.)+[\w-]{2,6})*)$' 
+
   Name:
     Type: String
 
@@ -19,8 +31,16 @@ Parameters:
   Environment:
     Type: String
 
+  CloudWatchLogsExpirationInDays:
+    Type: Number
+    Default: 14
+    Description: The number of days log events are kept in CloudWatch Logs.
+
 Conditions:
   IsProd: !Equals [!Ref Environment, PROD]
+
+  ShouldAllowSignUpEmailDomain:
+    !Not [!Equals [!Ref AllowedSignUpEmailDomain, ""]]
 
 Resources:
 
@@ -68,7 +88,10 @@ Resources:
     Type: "AWS::Cognito::UserPool"
     Properties:
       AdminCreateUserConfig:
-        AllowAdminCreateUserOnly: true
+        AllowAdminCreateUserOnly: !If
+          - ShouldAllowSignUpEmailDomain
+          - false
+          - true
         InviteMessageTemplate:
           EmailMessage:
             !Sub >
@@ -86,6 +109,11 @@ Resources:
         - email
       AutoVerifiedAttributes:
         - email
+      LambdaConfig: !If
+        - ShouldAllowSignUpEmailDomain
+        - PreAuthentication: !GetAtt CognitoUserPoolEmailDomainVerifyFunction.Arn
+          PreSignUp: !GetAtt CognitoUserPoolEmailDomainVerifyFunction.Arn
+        - !Ref AWS::NoValue
       Schema:
         - Required: true
           Name: email
@@ -136,6 +164,67 @@ Resources:
         !Ref AdminUsername
       UserPoolId:
         !Ref PCAUserPool
+
+  CognitoUserPoolEmailDomainVerifyFunction:
+    Type: AWS::Serverless::Function
+    Condition: ShouldAllowSignUpEmailDomain
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs18.x
+      Timeout: 3
+      Environment:
+        Variables:
+          ALLOWED_SIGNUP_EMAIL_DOMAINS: !Ref AllowedSignUpEmailDomain
+      InlineCode: |
+        exports.handler = async (event, context) => {
+          console.log(event);
+          const allowed_domains = (
+              process.env?.ALLOWED_SIGNUP_EMAIL_DOMAINS
+              .split(",").map(domain => {return domain.trim()})
+          );
+          const { email } = event.request?.userAttributes;
+          if (!email || !email.includes('@')) {
+            throw Error('Username does not exists or invalid email address');
+          }
+          const emailDomain = email?.split('@')[1];
+          if (!emailDomain || !allowed_domains) {
+            throw new Error('Server error - invalid configuration');
+          }
+          if (!allowed_domains.includes(emailDomain) && allowed_domains != "*") {
+            throw new Error('Invalid email address domain');
+          }
+          return event;
+        };
+      LoggingConfig:
+        LogGroup:
+          Fn::Sub: /${AWS::StackName}/lambda/CognitoUserPoolEmailDomainVerifyFunction
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W89
+            reason: Customer can use VPC if desired
+          - id: W92
+            reason: Customer can choose reserved concurrency based on their requirement.
+    DependsOn:
+      - CognitoUserPoolEmailDomainVerifyFunctionLogGroup
+
+  CognitoUserPoolEmailDomainVerifyFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName:
+        Fn::Sub: /${AWS::StackName}/lambda/CognitoUserPoolEmailDomainVerifyFunction
+      RetentionInDays:
+        Ref: CloudWatchLogsExpirationInDays
+
+  CognitoUserPoolEmailDomainVerifyPermission:
+    Type: AWS::Lambda::Permission
+    Condition: ShouldAllowSignUpEmailDomain
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref CognitoUserPoolEmailDomainVerifyFunction
+      Principal: cognito-idp.amazonaws.com
+      SourceAccount: !Ref AWS::AccountId
+      SourceArn: !GetAtt PCAUserPool.Arn
 
 Outputs:
   AdminUser:

--- a/pca-ui/cfn/lib/cognito.template
+++ b/pca-ui/cfn/lib/cognito.template
@@ -16,7 +16,8 @@ Parameters:
     Default: ""
     Description: >-
       Email address domain (example.com) or comma separated list of email domains  (example1.com,
-      example2.com) allowed to signin and signup using the web UI.
+      example2.com) allowed to signin and signup using the web UI. To allow signup from any domain, 
+      enter *.
       If left empty, signup via the web UI is disabled and users will have to be created
       using
       Cognito.

--- a/pca-ui/cfn/pca-ui.template
+++ b/pca-ui/cfn/pca-ui.template
@@ -21,7 +21,8 @@ Parameters:
     Default: ""
     Description: >-
       Email address domain (example.com) or comma separated list of email domains  (example1.com,
-      example2.com) allowed to signin and signup using the web UI.
+      example2.com) allowed to signin and signup using the web UI. To allow signup from any domain, 
+      enter *.
       If left empty, signup via the web UI is disabled and users will have to be created
       using
       Cognito.

--- a/pca-ui/cfn/pca-ui.template
+++ b/pca-ui/cfn/pca-ui.template
@@ -16,6 +16,17 @@ Parameters:
       AllowedPattern: ".+\\@.+\\..+"
       ConstraintDescription: Must be valid email address eg. johndoe@example.com
 
+  AllowedSignUpEmailDomain:
+    Type: String
+    Default: ""
+    Description: >-
+      Email address domain (example.com) or comma separated list of email domains  (example1.com,
+      example2.com) allowed to signin and signup using the web UI.
+      If left empty, signup via the web UI is disabled and users will have to be created
+      using
+      Cognito.
+    AllowedPattern: '^(\*||([\w-]+\.)+[\w-]{2,6}(, *([\w-]+\.)+[\w-]{2,6})*)$' 
+
   AudioBucket:
     Type: String
     Default: InputBucketName
@@ -128,6 +139,7 @@ Resources:
       Parameters:
         AdminUsername: !Ref AdminUsername
         AdminEmail: !Ref AdminEmail
+        AllowedSignUpEmailDomain: !Ref AllowedSignUpEmailDomain
         WebUri: !GetAtt Web.Outputs.Uri
         Environment: !Ref Environment
         Name: 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Disable checking if Bedrock models are enabled (default is set to true i.e check it which is the right setting for most cases).
2. Allow users to sign-up for access to Web UI when AllowedSignUpEmailDomain is populated (disable if left blank. enabled for all domains if * is entered).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
