### PR TITLE
Adding s3 bucket for storing cfn template, as it is now too large to work without one

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -137,7 +137,7 @@ aws cloudformation validate-template --template-url $template > /dev/null || exi
 echo "Outputs"
 echo Template URL: $template
 echo CF Launch URL: https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stacks/create/review?templateURL=${template}\&stackName=PCA
-echo CLI Deploy: aws cloudformation deploy --template-file `pwd`/build/packaged.template --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --stack-name PCA --parameter-overrides AdminEmail=YOUR_EMAIL
+echo CLI Deploy: aws cloudformation deploy --template-file `pwd`/build/packaged.template --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --stack-name PCA --s3-bucket ${BUCKET} --parameter-overrides AdminEmail=YOUR_EMAIL
 
 echo Done
 exit 0


### PR DESCRIPTION
The Command Line command recommended at the end of publish.sh no longer works, as the CFN is too large to work without specifying an S3 bucket. Added it to the command

<img width="2532" alt="Screenshot 2024-10-14 at 11 20 39" src="https://github.com/user-attachments/assets/56d6bd12-ecec-48e9-b53b-bf89a79efc53">
