### PR TITLE
Set x86_64 arch for local build

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -16,6 +16,11 @@
 # export AWS_DEFAULT_REGION=eu-west-1
 ##############################################################################################
 
+# Set architecture for npm/node
+export npm_config_arch=x64
+alias npm="arch -x86_64 npm"
+alias node="arch -x86_64 node"
+
 if ! [ -x "$(command -v npm)" ]; then
   echo 'Error: npm is not installed and required.' >&2
   exit 1


### PR DESCRIPTION
*Issue #, if available:*
Current publish.sh does not work with ARM chipsets such as the Apple M series.

*Description of changes:*
Explicitly set the node and NPM architecture to x86_64 for local builds within the publish.sh script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
