### PR TITLE
QuickSight Lambda Verification Timeout

### DIFF
--- a/pca-main-nokendra.template
+++ b/pca-main-nokendra.template
@@ -1027,6 +1027,7 @@ Resources:
     Properties:
       Handler: index.handler
       Runtime: python3.13
+      Timeout: 120
       Role: !GetAtt QuickSightEnabledCheckFunctionRole.Arn
       Code: 
         ZipFile: !Sub |

--- a/pca-main.template
+++ b/pca-main.template
@@ -1227,6 +1227,7 @@ Resources:
     Properties:
       Handler: index.handler
       Runtime: python3.13
+      Timeout: 120
       Role: !GetAtt QuickSightEnabledCheckFunctionRole.Arn
       Code: 
         ZipFile: !Sub |


### PR DESCRIPTION
*Description of changes:*

The Lambda function that verifies if QuickSight is installed in the AWS account did not have a timeout and used the default of 3 seconds. This verification can take longer than 3 seconds, causing the CloudFormation script to fail. I added a Timeout to the Lambda of 120 seconds, giving it sufficient time to complete the verification.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
