### PR TITLE
detect_sentiment api has limits of input size of 5kb

### DIFF
--- a/pca-server/src/pca/pca-aws-sf-process-turn-by-turn.py
+++ b/pca-server/src/pca/pca-aws-sf-process-turn-by-turn.py
@@ -355,8 +355,16 @@ class TranscribeParser:
         Perform sentiment analysis, but try and avert throttling by trying one more time if this exceptions.
         It is not a replacement for limit increases, but will help limit failures if usage suddenly grows
         """
+
+        MAX_TEXT_SIZE = 5000 # This is limited by the AWS comprehend services:  https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/comprehend/client/detect_sentiment.html
         sentimentResponse = {}
         counter = 0
+
+        if isinstance(text, str):
+            text = text.encode('utf-8') # Convert to bytes
+            text = text[:MAX_TEXT_SIZE] # Truncate if too long for AWS Comprehend
+            text = text.decode('utf-8', 'ignore') # Convert back to string
+                
         while sentimentResponse == {}:
             try:
                 # Get the sentiment, and strip off the MIXED response (as we won't be using it)


### PR DESCRIPTION
Code has been updated to make sure the api does not failed

*Issue #, if available:*

When the audio transcribe results are more than 5000 bytes, the detect_sentiment API call fails due to its input limitations
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/comprehend/client/detect_sentiment.html

*Description of changes:*
Check the input text size to make sure it's within the 5000 bytes limit, and if it exists, then truncate it to use the first 5000 bytes. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
