### PR TITLE
fix #300 - glue table definitions broken

### DIFF
--- a/pca-server/cfn/lib/glue-database.template
+++ b/pca-server/cfn/lib/glue-database.template
@@ -86,7 +86,7 @@ Resources:
             - - '/* Presto View: '
               - Fn::Base64: !Sub |
                   {
-                  "originalSql": "SELECT regexp_extract(\"$path\", '[^/]+$') filename, conversationanalytics.languagecode, conversationanalytics.speakerlabels[1].displaytext speaker_0, CAST(conversationanalytics.duration AS double) duration, conversationanalytics.conversationtime, date_parse(substr(conversationanalytics.conversationtime, 1, 19), '%Y-%m-%d %H:%i:%s') formatedconversationtime FROM ${Database}.${ParsedResultsTable}",
+                  "originalSql": "SELECT regexp_extract(\"$path\", '[^/]+$') filename, conversationanalytics.languagecode, conversationanalytics.speakerlabels[1].displaytext speaker_0, CAST(conversationanalytics.duration AS double) duration, conversationanalytics.conversationtime, date_parse(substr(conversationanalytics.conversationtime, 1, 19), '%Y-%m-%d %H:%i:%s') formatedconversationtime FROM \"${Database}\".\"${ParsedResultsTable}\"",
                   "catalog": "awsdatacatalog",
                   "schema": "${Database}",
                   "columns": [
@@ -173,7 +173,7 @@ Resources:
             - - '/* Presto View: '
               - Fn::Base64: !Sub |
                   {
-                  "originalSql": "SELECT regexp_extract(\"$path\", '[^/]+$') filename, conversationanalytics.languagecode, conversationanalytics.speakerlabels[1].displaytext speaker_0, conversationanalytics.conversationtime, CAST(conversationanalytics.duration AS double) duration, date_parse(substr(conversationanalytics.conversationtime, 1, 19), '%Y-%m-%d %H:%i:%s') formatedconversationtime, segment.segmentstarttime, segment.segmentendtime, segment.segmentspeaker, segment.sentimentispositive, segment.sentimentisnegative, (CASE WHEN (segment.sentimentispositive = 1) THEN 'Positive' WHEN (segment.sentimentisnegative = 1) THEN 'Negative' ELSE 'Neutral' END) sentiment, segment.sentimentscore, segment.displaytext, segment.textedited, segment.entitiesdetected, (CASE WHEN ((conversationanalytics.speakerlabels[1].displaytext = 'Agent') AND (segment.segmentspeaker = 'spk_0')) THEN 'Agent' WHEN ((conversationanalytics.speakerlabels[1].displaytext = 'Agent') AND (segment.segmentspeaker = 'spk_1')) THEN 'Caller' END) Speaker FROM (${Database}.${ParsedResultsTable} CROSS JOIN UNNEST(speechsegments) t (segment))",
+                  "originalSql": "SELECT regexp_extract(\"$path\", '[^/]+$') filename, conversationanalytics.languagecode, conversationanalytics.speakerlabels[1].displaytext speaker_0, conversationanalytics.conversationtime, CAST(conversationanalytics.duration AS double) duration, date_parse(substr(conversationanalytics.conversationtime, 1, 19), '%Y-%m-%d %H:%i:%s') formatedconversationtime, segment.segmentstarttime, segment.segmentendtime, segment.segmentspeaker, segment.sentimentispositive, segment.sentimentisnegative, (CASE WHEN (segment.sentimentispositive = 1) THEN 'Positive' WHEN (segment.sentimentisnegative = 1) THEN 'Negative' ELSE 'Neutral' END) sentiment, segment.sentimentscore, segment.displaytext, segment.textedited, segment.entitiesdetected, (CASE WHEN ((conversationanalytics.speakerlabels[1].displaytext = 'Agent') AND (segment.segmentspeaker = 'spk_0')) THEN 'Agent' WHEN ((conversationanalytics.speakerlabels[1].displaytext = 'Agent') AND (segment.segmentspeaker = 'spk_1')) THEN 'Caller' END) Speaker FROM (\"${Database}\".\"${ParsedResultsTable}\" CROSS JOIN UNNEST(speechsegments) t (segment))",
                   "catalog": "awsdatacatalog",
                   "schema": "${Database}",
                   "columns": [
@@ -310,7 +310,7 @@ Resources:
             - - '/* Presto View: '
               - Fn::Base64: !Sub |
                   {
-                  "originalSql": "SELECT filename, languagecode, duration, conversationtime, formatedconversationtime, segmentstarttime, segmentendtime, segmentspeaker, speaker, sentimentispositive, sentimentisnegative, (CASE WHEN (sentimentispositive = 1) THEN 'Positive' WHEN (sentimentisnegative = 1) THEN 'Negative' ELSE 'Neutral' END) sentiment, sentimentscore, displaytext, textedited, entity.beginoffset, entity.endoffset, entity.score, entity.text, entity.type FROM(${Database}.${ConversationSegmentsView} CROSS JOIN UNNEST(entitiesdetected) t (entity))",
+                  "originalSql": "SELECT filename, languagecode, duration, conversationtime, formatedconversationtime, segmentstarttime, segmentendtime, segmentspeaker, speaker, sentimentispositive, sentimentisnegative, (CASE WHEN (sentimentispositive = 1) THEN 'Positive' WHEN (sentimentisnegative = 1) THEN 'Negative' ELSE 'Neutral' END) sentiment, sentimentscore, displaytext, textedited, entity.beginoffset, entity.endoffset, entity.score, entity.text, entity.type FROM(\"${Database}\".\"${ConversationSegmentsView}\" CROSS JOIN UNNEST(entitiesdetected) t (entity))",
                   "catalog": "awsdatacatalog",
                   "schema": "${Database}",
                   "columns": [


### PR DESCRIPTION
*Issue #, if available:*
#300 

*Description of changes:*

Add quotes around database and table names in view definitions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
