### PR TITLE
Fix: Added STACK_NAME environment variable to bulk workflow Lambda functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Lambda Runtime to NodeJS 22.x
 - #299 - handle comprehend detect_sentiment api has limits of input size of 5kb
 - #310 - Change Default Model from Nova-Lite to Nova-Pro for GenAI Queries and Summarization in PCA CFN Templates
+- Added missing STACK_NAME environment variable to BulkFilesCount Lambda function to fix ParameterNotFound error
 - #305 - Extend query window to 5 years and modify sample file timestamps
 - misc dependabot PRs
 

--- a/pca-server/cfn/lib/bulk.template
+++ b/pca-server/cfn/lib/bulk.template
@@ -21,6 +21,9 @@ Resources:
     Properties:
       CodeUri:  ../../src/pca
       Handler: pca-aws-sf-bulk-files-count.lambda_handler
+      Environment:
+        Variables:
+          STACK_NAME: !Ref ParentStackName
       Policies:
       - Statement:
         - Sid: S3BucketReadPolicy    
@@ -51,6 +54,9 @@ Resources:
       CodeUri:  ../../src/pca
       Handler: pca-aws-sf-bulk-move-files.lambda_handler
       Timeout: 300
+      Environment:
+        Variables:
+          STACK_NAME: !Ref ParentStackName
       Policies:
       - Statement:
         - Sid: S3BucketReadWritePolicy    
@@ -86,6 +92,9 @@ Resources:
       CodeUri:  ../../src/pca
       Handler: pca-aws-sf-bulk-queue-space.lambda_handler
       Timeout: 30
+      Environment:
+        Variables:
+          STACK_NAME: !Ref ParentStackName
       Policies:
         - arn:aws:iam::aws:policy/AmazonTranscribeReadOnlyAccess
 


### PR DESCRIPTION
*Issue #, if available:*

The problem is that when the Step Function is trying to retrieve the parameter, it's looking for "None-BulkUploadBucket" instead of "pca-july2-BulkUploadBucket". This confirms that the STACK_NAME environment variable is not set in the Lambda function


*Description of changes:*
Add the STACK_NAME environment variable to the Lambda functions in the bulk.template file


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
